### PR TITLE
[Feature] Apple login

### DIFF
--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleApi.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleApi.kt
@@ -1,0 +1,11 @@
+package com.sseudam.client.oauth
+
+import com.sseudam.client.oauth.response.ApplePublicKeysResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+
+@FeignClient(name = "apple-auth-api", url = "https://appleid.apple.com")
+internal interface AppleApi {
+    @GetMapping("/auth/keys")
+    fun getApplePublicKeys(): ApplePublicKeysResponse
+}

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleClient.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleClient.kt
@@ -1,0 +1,85 @@
+package com.sseudam.client.oauth
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nimbusds.jose.JOSEException
+import com.nimbusds.jose.crypto.RSASSAVerifier
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import com.sseudam.support.error.AuthenticationErrorException
+import com.sseudam.support.error.AuthenticationErrorType
+import org.springframework.stereotype.Component
+import java.text.ParseException
+import java.util.Date
+
+@Component
+class AppleClient internal constructor(
+    private val appleApi: AppleApi,
+    private val appleProperties: AppleProperties,
+    private val objectMapper: ObjectMapper,
+) {
+    fun getUserInfo(token: String): AppleClientResult {
+        val signedJWT: SignedJWT
+        val jwtClaims: JWTClaimsSet
+        try {
+            signedJWT = SignedJWT.parse(token)
+            jwtClaims = signedJWT.jwtClaimsSet
+        } catch (e: ParseException) {
+            throw AuthenticationErrorException(AuthenticationErrorType.INVALID_APPLE_TOKEN)
+        }
+
+        return try {
+            AppleClientResult(
+                jwtClaims.getStringClaim("sub"),
+                jwtClaims.getStringClaim("email"),
+            )
+        } catch (e: ParseException) {
+            throw AuthenticationErrorException(AuthenticationErrorType.INVALID_APPLE_TOKEN)
+        }
+    }
+
+    fun verify(token: String): Boolean {
+        val signedJWT: SignedJWT
+        val jwtClaims: JWTClaimsSet
+        try {
+            signedJWT = SignedJWT.parse(token)
+            jwtClaims = signedJWT.jwtClaimsSet
+        } catch (e: ParseException) {
+            return false
+        }
+
+        if (!isSignatureValid(signedJWT)) {
+            return false
+        }
+        val currentDate = Date(System.currentTimeMillis())
+        // audience 확인 부분 개선
+        val bundleId = jwtClaims.audience.firstOrNull()
+        if (bundleId != appleProperties.bundleId) return false
+
+        val appleUrl = jwtClaims.issuer
+        return currentDate.before(jwtClaims.expirationTime) && appleUrl == "https://appleid.apple.com"
+    }
+
+    private fun isSignatureValid(signedJWT: SignedJWT): Boolean {
+        val appleKeys = appleApi.getApplePublicKeys().keys
+        for (key in appleKeys) {
+            try {
+                val rsaKey = JWK.parse(objectMapper.writeValueAsString(key)) as RSAKey
+                val publicKey = rsaKey.toRSAPublicKey()
+                val verifier = RSASSAVerifier(publicKey)
+                if (signedJWT.verify(verifier)) {
+                    return true
+                }
+            } catch (e: JsonProcessingException) {
+                throw AuthenticationErrorException(AuthenticationErrorType.INVALID_APPLE_TOKEN)
+            } catch (e: ParseException) {
+                throw AuthenticationErrorException(AuthenticationErrorType.INVALID_APPLE_TOKEN)
+            } catch (e: JOSEException) {
+                throw AuthenticationErrorException(AuthenticationErrorType.INVALID_APPLE_TOKEN)
+            }
+        }
+        return false
+    }
+}

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleClientResult.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleClientResult.kt
@@ -1,0 +1,6 @@
+package com.sseudam.client.oauth
+
+data class AppleClientResult(
+    val id: String,
+    val email: String,
+)

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleProperties.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/AppleProperties.kt
@@ -1,0 +1,8 @@
+package com.sseudam.client.oauth
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("apple")
+data class AppleProperties(
+    val bundleId: String,
+)

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/KaKaoApi.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/KaKaoApi.kt
@@ -1,0 +1,21 @@
+package com.sseudam.client.oauth
+
+import com.sseudam.client.oauth.response.KaKaoUserResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+
+@FeignClient(value = "kakao-auth-api", url = "https://kapi.kakao.com")
+internal interface KaKaoApi {
+    @RequestMapping(
+        method = [RequestMethod.GET],
+        value = ["/v2/user/me"],
+        consumes = ["application/x-www-form-urlencoded;charset=utf-8"],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    )
+    fun getKaKaoUserInfo(
+        @RequestHeader(name = "Authorization") authorization: String,
+    ): KaKaoUserResponse
+}

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/KaKaoClient.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/KaKaoClient.kt
@@ -1,0 +1,10 @@
+package com.sseudam.client.oauth
+
+import org.springframework.stereotype.Component
+
+@Component
+class KaKaoClient internal constructor(
+    private val kaKaoApi: KaKaoApi,
+) {
+    fun getUserInfo(token: String): KaKaoClientResult = kaKaoApi.getKaKaoUserInfo("Bearer $token").toResult()
+}

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/KaKaoClientResult.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/KaKaoClientResult.kt
@@ -1,0 +1,8 @@
+package com.sseudam.client.oauth
+
+data class KaKaoClientResult(
+    val id: String,
+    val email: String,
+    val name: String,
+    val nickname: String,
+)

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/OAuthFeignConfig.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/OAuthFeignConfig.kt
@@ -1,0 +1,8 @@
+package com.sseudam.client.oauth
+
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients
+internal class OAuthFeignConfig

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/OAuthService.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/OAuthService.kt
@@ -1,0 +1,28 @@
+package com.sseudam.client.oauth
+
+import com.sseudam.support.error.AuthenticationErrorException
+import com.sseudam.support.error.AuthenticationErrorType
+import feign.FeignException
+import org.springframework.stereotype.Service
+
+@Service
+class OAuthService(
+    private val kaKaoClient: KaKaoClient,
+    private val appleClient: AppleClient,
+) {
+    fun getKaKaoUserInfo(token: String): KaKaoClientResult =
+        try {
+            kaKaoClient.getUserInfo(token)
+        } catch (e: FeignException) {
+            if (e.status() == 401) {
+                throw AuthenticationErrorException(AuthenticationErrorType.INVALID_KAKAO_TOKEN)
+            } else {
+                throw AuthenticationErrorException(AuthenticationErrorType.INVALID_KAKAO_TOKEN, e.message)
+            }
+        }
+
+    fun getAppleUserInfo(token: String): AppleClientResult {
+        if (!appleClient.verify(token)) throw AuthenticationErrorException(AuthenticationErrorType.INVALID_APPLE_TOKEN)
+        return appleClient.getUserInfo(token)
+    }
+}

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/request/AppleTokenRequest.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/request/AppleTokenRequest.kt
@@ -1,0 +1,23 @@
+package com.sseudam.client.oauth.request
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AppleTokenRequest(
+    @JsonProperty("code")
+    val code: String,
+    @JsonProperty("client_id")
+    val clientId: String,
+    @JsonProperty("client_secret")
+    val clientSecret: String,
+    @JsonProperty("grant_type")
+    val grantType: String,
+) {
+    companion object {
+        fun of(
+            code: String,
+            clientId: String,
+            clientSecret: String,
+            grantType: String,
+        ): AppleTokenRequest = AppleTokenRequest(code, clientId, clientSecret, grantType)
+    }
+}

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/response/ApplePublicKeysResponse.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/response/ApplePublicKeysResponse.kt
@@ -1,0 +1,14 @@
+package com.sseudam.client.oauth.response
+
+data class ApplePublicKeysResponse(
+    val keys: List<Key>,
+)
+
+data class Key(
+    val kty: String,
+    val kid: String,
+    val use: String,
+    val alg: String,
+    val n: String,
+    val e: String,
+)

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/response/AppleTokenResponse.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/response/AppleTokenResponse.kt
@@ -1,0 +1,26 @@
+package com.sseudam.client.oauth.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AppleTokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+    @JsonProperty("expires_in")
+    val expiresIn: Long,
+    @JsonProperty("id_token")
+    val idToken: String,
+    @JsonProperty("refresh_token")
+    val refreshToken: String,
+    @JsonProperty("token_type")
+    val tokenType: String,
+) {
+    companion object {
+        fun of(
+            accessToken: String,
+            expiresIn: Long,
+            idToken: String,
+            refreshToken: String,
+            tokenType: String,
+        ) = AppleTokenResponse(accessToken, expiresIn, idToken, refreshToken, tokenType)
+    }
+}

--- a/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/response/KaKaoUserResponse.kt
+++ b/sseudam-clients/oauth-client/src/main/kotlin/com/sseudam/client/oauth/response/KaKaoUserResponse.kt
@@ -1,0 +1,40 @@
+package com.sseudam.client.oauth.response
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.sseudam.client.oauth.KaKaoClientResult
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KaKaoUserResponse(
+    val id: String,
+    @field:JsonProperty("kakao_account")
+    val kaKaoAccount: KaKaoAccount,
+) {
+    fun toResult(): KaKaoClientResult =
+        KaKaoClientResult(
+            id = id,
+            email = kaKaoAccount.email ?: "",
+            name = kaKaoAccount.name ?: "쓰담",
+            nickname = kaKaoAccount.kaKaoProfile.nickname ?: "쓰담",
+        )
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KaKaoAccount(
+    val email: String?,
+    val name: String?,
+    @field:JsonProperty("profile")
+    val kaKaoProfile: KaKaoProfile,
+    @field:JsonProperty("phone_number")
+    val phoneNumber: String?,
+    @field:JsonProperty("birthyear")
+    val birthYear: String?,
+    @field:JsonProperty("birthday")
+    val birthDay: String?,
+    val gender: String?,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KaKaoProfile(
+    val nickname: String?,
+)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/AuthController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/AuthController.kt
@@ -1,0 +1,129 @@
+package com.sseudam.presentation.v1.auth
+
+import com.sseudam.auth.AuthenticationFacade
+import com.sseudam.auth.AuthenticationService
+import com.sseudam.auth.CredentialSocial
+import com.sseudam.client.oauth.OAuthService
+import com.sseudam.presentation.v1.annotation.ApiV1Controller
+import com.sseudam.presentation.v1.auth.request.LoginRequest
+import com.sseudam.presentation.v1.auth.request.RefreshTokenRequest
+import com.sseudam.presentation.v1.auth.request.SignUpRequest
+import com.sseudam.presentation.v1.auth.request.SignUpSocialRequest
+import com.sseudam.presentation.v1.auth.request.TokenRequest
+import com.sseudam.presentation.v1.auth.response.LogoutResponse
+import com.sseudam.presentation.v1.auth.response.SignUpResponse
+import com.sseudam.presentation.v1.auth.response.TokenResponse
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
+import com.sseudam.user.SocialType
+import com.sseudam.user.User
+import com.sseudam.user.UserService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+
+@Tag(name = "\uD83D\uDD11 Auth API", description = "인증 관련 API")
+@ApiV1Controller
+class AuthController(
+    private val authenticationService: AuthenticationService,
+    private val authenticationFacade: AuthenticationFacade,
+    private val oAuthService: OAuthService,
+    private val userService: UserService,
+) {
+    @Operation(summary = "이메일 로그인", description = "로그인합니다.")
+    @PostMapping("/auth/login")
+    fun login(
+        @RequestHeader(name = "X-DEVICE-ID") deviceId: String?,
+        @RequestBody request: LoginRequest,
+    ): TokenResponse {
+        // TODO: 이메일 로그인 도입 시 password Encoder 적용 및 validation 추가
+        val findUser = userService.getUser(request.loginId, request.password)
+        val token = authenticationService.login(deviceId, User(findUser.id, findUser.key), request.toCredentialSseudam())
+        return TokenResponse.toResponse(false, token)
+    }
+
+    @Operation(summary = "이메일 회원가입", description = "회원가입합니다.")
+    @PostMapping("/auth/signup")
+    suspend fun signUp(
+        @RequestBody request: SignUpRequest,
+    ): SignUpResponse {
+        userService.create(request.toNewUser())
+        return SignUpResponse("회원가입에 성공했습니다.")
+    }
+
+    @Operation(summary = "카카오 로그인", description = "카카오 소셜 로그인합니다.")
+    @PostMapping("/auth/social-login/kakao")
+    suspend fun socialKakaoLogin(
+        @RequestBody request: TokenRequest,
+    ): TokenResponse {
+        val socialInfo = oAuthService.getKaKaoUserInfo(request.token)
+        val (isTemporaryToken, token) =
+            authenticationFacade.socialLogin(
+                // TODO: deviceId 는 추후에 추가
+                deviceId = "",
+                credentialSocial =
+                    CredentialSocial(
+                        email = socialInfo.email,
+                        name = socialInfo.name,
+                        socialId = socialInfo.id,
+                        socialType = SocialType.KAKAO,
+                    ),
+            )
+        return TokenResponse.toResponse(isTemporaryToken, token)
+    }
+
+    @Operation(summary = "애플 소셜 로그인", description = "애플 소셜 로그인합니다.")
+    @PostMapping("/auth/social-login/apple")
+    suspend fun socialAppleLogin(
+        @RequestBody request: TokenRequest,
+    ): TokenResponse {
+        val socialInfo = oAuthService.getAppleUserInfo(request.token)
+        val (isTemporaryToken, token) =
+            authenticationFacade.socialLogin(
+                // TODO: deviceId 는 추후에 추가
+                deviceId = "",
+                credentialSocial =
+                    CredentialSocial(
+                        email = socialInfo.email,
+                        name = null,
+                        socialId = socialInfo.id,
+                        socialType = SocialType.APPLE,
+                    ),
+            )
+        return TokenResponse.toResponse(isTemporaryToken, token)
+    }
+
+    @Operation(summary = "소셜 회원가입", description = "소셜 회원 가입합니다.")
+    @PostMapping("/auth/social-signup")
+    suspend fun socialSignUp(
+        @RequestBody request: SignUpSocialRequest,
+    ): SignUpResponse {
+        val tempUser = userService.getSocialUserByEmail(request.email)
+        if (tempUser == null) {
+            throw ErrorException(ErrorType.NOT_FOUND_DATA)
+        } else {
+            userService.updateName(tempUser.key, request.name)
+        }
+        return SignUpResponse("회원가입에 성공했습니다.")
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃합니다.")
+    @PostMapping("/auth/logout")
+    fun logout(
+        @RequestBody request: TokenRequest,
+    ): LogoutResponse {
+        val logoutUserKey = authenticationService.logout(request.token)
+        return LogoutResponse("$logoutUserKey: 로그아웃 되었습니다.")
+    }
+
+    @Operation(summary = "토큰 재발급", description = "토큰을 재발급합니다.")
+    @PostMapping("/auth/reissue")
+    fun reissueToken(
+        @RequestBody request: RefreshTokenRequest,
+    ): TokenResponse {
+        val token = authenticationService.renew(request.toRefreshToken())
+        return TokenResponse.toResponse(false, token)
+    }
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/LoginRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/LoginRequest.kt
@@ -1,0 +1,18 @@
+package com.sseudam.presentation.v1.auth.request
+
+import com.sseudam.auth.CredentialSseudam
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "로그인 요청")
+data class LoginRequest(
+    @Schema(description = "로그인 아이디", example = "test@test.com")
+    val loginId: String,
+    @Schema(description = "비밀번호", example = "password")
+    val password: String,
+) {
+    fun toCredentialSseudam(): CredentialSseudam =
+        CredentialSseudam(
+            loginId = loginId,
+            password = password,
+        )
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/RefreshTokenRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/RefreshTokenRequest.kt
@@ -1,0 +1,15 @@
+package com.sseudam.presentation.v1.auth.request
+
+import com.sseudam.auth.token.RefreshToken
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "리프레시 토큰 요청")
+data class RefreshTokenRequest(
+    @Schema(description = "리프레시 토큰", example = "refresh_token")
+    val refreshToken: String,
+) {
+    fun toRefreshToken(): RefreshToken =
+        RefreshToken(
+            token = refreshToken,
+        )
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpRequest.kt
@@ -1,0 +1,37 @@
+package com.sseudam.presentation.v1.auth.request
+
+import com.sseudam.auth.AuthorityType
+import com.sseudam.auth.GrantedAuthority
+import com.sseudam.auth.NewAuthenticationSseudam
+import com.sseudam.user.NewUser
+import com.sseudam.user.SocialType
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "회원가입 요청 Json")
+data class SignUpRequest(
+    @Schema(description = "이메일", example = "test@test.com")
+    val email: String,
+    @Schema(description = "비밀번호", example = "password")
+    val password: String,
+    @Schema(description = "이름", example = "윤범차")
+    val name: String?,
+    @Schema(description = "이름", example = "닉네임이야")
+    val nickname: String?,
+) {
+    fun toNewUser(): NewUser =
+        NewUser(
+            email = email,
+            name = name,
+            nickname = nickname,
+            password = password,
+            socialId = "",
+            socialType = SocialType.SSEUDAM,
+        )
+
+    fun toNewAuthenticationSseudam(): NewAuthenticationSseudam =
+        NewAuthenticationSseudam(
+            loginId = email,
+            password = password,
+            grantedAuthority = GrantedAuthority(AuthorityType.USER),
+        )
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpSocialRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpSocialRequest.kt
@@ -1,0 +1,36 @@
+package com.sseudam.presentation.v1.auth.request
+
+import com.sseudam.auth.AuthorityType
+import com.sseudam.auth.GrantedAuthority
+import com.sseudam.auth.NewAuthenticationSocial
+import com.sseudam.user.NewUser
+import com.sseudam.user.SocialType
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "소셜 회원가입 요청 Json")
+data class SignUpSocialRequest(
+    val email: String,
+    val name: String,
+) {
+    fun toNewUser(
+        socialId: String,
+        socialType: SocialType,
+    ): NewUser =
+        NewUser(
+            email = email,
+            name = name,
+            socialId = socialId,
+            socialType = socialType,
+        )
+
+    fun toNewAuthenticationSocial(
+        socialId: String,
+        socialType: SocialType,
+    ): NewAuthenticationSocial =
+        NewAuthenticationSocial(
+            loginId = email,
+            socialId = socialId,
+            socialType = socialType,
+            grantedAuthority = GrantedAuthority(AuthorityType.USER),
+        )
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/TokenRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/TokenRequest.kt
@@ -1,0 +1,9 @@
+package com.sseudam.presentation.v1.auth.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "토큰 요청 Json")
+data class TokenRequest(
+    @Schema(description = "토큰", example = "id_token or access_token")
+    val token: String,
+)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/response/LogoutResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/response/LogoutResponse.kt
@@ -1,0 +1,9 @@
+package com.sseudam.presentation.v1.auth.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "로그아웃 응답 Json")
+data class LogoutResponse(
+    @Schema(description = "로그아웃 메시지", example = "userKey: 로그아웃 되었습니다.")
+    val message: String,
+)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/response/SignUpResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/response/SignUpResponse.kt
@@ -1,0 +1,9 @@
+package com.sseudam.presentation.v1.auth.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "회원가입 응답 Json")
+data class SignUpResponse(
+    @Schema(description = "회원가입 메시지", example = "회원가입에 성공했습니다.")
+    val message: String,
+)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/response/TokenResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/response/TokenResponse.kt
@@ -1,0 +1,26 @@
+package com.sseudam.presentation.v1.auth.response
+
+import com.sseudam.auth.token.Token
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "토큰 응답 Json")
+data class TokenResponse(
+    @Schema(description = "임시 토큰 여부", example = "false")
+    val isTemporaryToken: Boolean = false,
+    @Schema(description = "accessToken", example = "accessToken")
+    val accessToken: String,
+    @Schema(description = "refreshToken", example = "refreshToken")
+    val refreshToken: String,
+) {
+    companion object {
+        fun toResponse(
+            isTemporaryToken: Boolean,
+            token: Token,
+        ): TokenResponse =
+            TokenResponse(
+                isTemporaryToken = isTemporaryToken,
+                accessToken = token.accessToken,
+                refreshToken = token.refreshToken,
+            )
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationProcessor.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationProcessor.kt
@@ -13,7 +13,7 @@ class AuthenticationProcessor(
     private val tokenRepository: TokenRepository,
     private val authenticationHistoryWriter: AuthenticationHistoryWriter,
 ) {
-    fun login(
+    fun socialLogin(
         deviceId: String?,
         user: User,
         credentialSseudam: CredentialSseudam,
@@ -36,7 +36,7 @@ class AuthenticationProcessor(
             )
         }
 
-    fun login(
+    fun socialLogin(
         deviceId: String,
         socialUser: SocialUser,
     ): Token =

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationService.kt
@@ -15,7 +15,7 @@ class AuthenticationService(
         user: User,
         credentialSseudam: CredentialSseudam,
     ): Token =
-        authenticationProcessor.login(
+        authenticationProcessor.socialLogin(
             deviceId = deviceId,
             user = user,
             credentialSseudam = credentialSseudam,
@@ -25,7 +25,7 @@ class AuthenticationService(
         deviceId: String,
         socialUser: SocialUser,
     ): Token =
-        authenticationProcessor.login(
+        authenticationProcessor.socialLogin(
             deviceId = deviceId,
             socialUser = socialUser,
         )
@@ -34,7 +34,7 @@ class AuthenticationService(
 
     fun logout(token: String): String = authenticationProcessor.remove(token)
 
-    fun delete(userKey: String) {
+    fun withdrawUser(userKey: String) {
         authenticationProcessor.withdrawal(userKey)
     }
 }

--- a/sseudam-storage/redis/src/main/kotlin/com/sseudam/storage/redis/config/AuthenticationRedissonConfig.kt
+++ b/sseudam-storage/redis/src/main/kotlin/com/sseudam/storage/redis/config/AuthenticationRedissonConfig.kt
@@ -13,7 +13,13 @@ class AuthenticationRedissonConfig(
     @Bean
     fun authRedissonClient(): RedissonClient {
         val config = Config()
-        config.useSingleServer().setAddress("redis://" + authenticationRedisProperties.host + ":" + authenticationRedisProperties.port)
+        config
+            .useSingleServer()
+            .setAddress("redis://${authenticationRedisProperties.host}:${authenticationRedisProperties.port}")
+            .setConnectionMinimumIdleSize(1)
+            .setConnectionPoolSize(10)
+            .setConnectTimeout(1500)
+            .setRetryAttempts(3)
         return Redisson.create(config)
     }
 }

--- a/sseudam-storage/redis/src/main/kotlin/com/sseudam/storage/redis/config/CoreRedisConfig.kt
+++ b/sseudam-storage/redis/src/main/kotlin/com/sseudam/storage/redis/config/CoreRedisConfig.kt
@@ -21,10 +21,12 @@ class CoreRedisConfig(
     @Bean
     fun coreRedisTemplate(
         @Qualifier("coreRedisConnectionFactory") redisConnectionFactory: RedisConnectionFactory,
-    ): RedisTemplate<*, *> =
-        RedisTemplate<Any, Any>().apply {
+    ): RedisTemplate<String, String> =
+        RedisTemplate<String, String>().apply {
             connectionFactory = redisConnectionFactory
             keySerializer = StringRedisSerializer.UTF_8
             valueSerializer = StringRedisSerializer.UTF_8
+            hashKeySerializer = StringRedisSerializer.UTF_8
+            hashValueSerializer = StringRedisSerializer.UTF_8
         }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #7 

## 📌 작업 내용 및 특이 사항

- b05969535cc8410bbc00103617ffd959780386ac: oauth client에서 애플 로그인(+카카오) 구현

## 📝 참고

- 테스트 계정 생성을 위한 로그인ID/패스워드도 구현

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive authentication and authorization REST API endpoints, including email and social (Kakao, Apple) login, signup, logout, and token reissue.
  - Added support for OAuth integration with Kakao and Apple, enabling user info retrieval and token validation.
  - Implemented data models and request/response formats for authentication flows, including login, signup, token, and logout operations.

- **Improvements**
  - Enhanced Redis configuration for improved connection management and consistent data serialization.

- **Refactor**
  - Renamed certain authentication service methods for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->