### PR TITLE
[Feature] Update Admin Suggestion

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -56,4 +56,9 @@ class AdminFacade(
     ): List<SpotReport.Info> = reportService.findReportsBy(offsetPageRequest, searchType)
 
     fun findReportDetails(reportId: Long): SpotReport.Info = reportService.findSpotReportById(reportId)
+
+    fun updateSuggestionStatus(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info = suggestionService.updateSuggestion(suggestionId, status)
 }

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/infrastructure/AdminEntity.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/infrastructure/AdminEntity.kt
@@ -6,10 +6,10 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
 
-@Table(name = "t_admin")
 @Entity
+@Table(name = "t_admin")
 class AdminEntity(
-    @Column(columnDefinition = "varchar(15) not null")
+    @Column(columnDefinition = "varchar(15)")
     val name: String,
     val loginId: String,
     val password: String,

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
@@ -38,6 +38,7 @@ class AdminController(
         return AdminTokenResponse.of(token)
     }
 
+    /** 어드민 사용자 API */
     @Operation(summary = "사용자 리스트 조회", description = "사용자 리스트를 조회합니다.")
     @GetMapping("/users")
     fun findUsersByPage(
@@ -54,6 +55,7 @@ class AdminController(
         @PathVariable("userId") userId: Long,
     ): UserResponse = UserResponse.of(adminFacade.findOneUser(userId))
 
+    /** 어드민 제보 API */
     @Operation(summary = "제보 리스트 조회", description = "제보 리스트를 조회합니다.")
     @GetMapping("/suggestions")
     fun findSuggestionsByPage(
@@ -78,6 +80,7 @@ class AdminController(
         @RequestParam status: SuggestionStatus,
     ) = adminFacade.updateSuggestionStatus(suggestionId, status)
 
+    /** 어드민 신고 API */
     @Operation(summary = "신고 리스트 조회", description = "신고 리스트를 조회합니다.")
     @GetMapping("/reports")
     fun findReportsByPage(

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -69,6 +70,13 @@ class AdminController(
     fun findSuggestionDetails(
         @PathVariable suggestionId: Long,
     ): SpotSuggestionResponse = SpotSuggestionResponse.of(adminFacade.findSuggestionDetails(suggestionId))
+
+    @Operation(summary = "제보 반영", description = "제보 상태 변경과 생성을 합니다.")
+    @PutMapping("/suggestions/{suggestionId}")
+    fun updateSuggestionStatus(
+        @PathVariable suggestionId: Long,
+        @RequestParam status: SuggestionStatus,
+    ) = adminFacade.updateSuggestionStatus(suggestionId, status)
 
     @Operation(summary = "신고 리스트 조회", description = "신고 리스트를 조회합니다.")
     @GetMapping("/reports")

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
@@ -27,13 +27,14 @@ class SuggestionController(
         val suggestion =
             suggestionService.createSpotSuggestion(
                 SpotSuggestion.Create(
-                    user.id,
-                    request.latitude,
-                    request.longitude,
-                    request.region,
-                    request.city,
-                    request.site,
-                    request.trashType,
+                    userId = user.id,
+                    spotName = request.spotName,
+                    latitude = request.latitude,
+                    longitude = request.longitude,
+                    region = request.region,
+                    city = request.city,
+                    site = request.site,
+                    trashType = request.trashType,
                 ),
             )
         return SuggestionImageUrlResponse.of(suggestion.first, suggestion.second)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/request/SpotSuggestionCreateRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/request/SpotSuggestionCreateRequest.kt
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "제보하기 요청 Json")
 data class SpotSuggestionCreateRequest(
+    @Schema(description = "쓰레기통 이름", example = "우리집 앞")
+    val spotName: String,
     @Schema(description = "위도", example = "37.566535")
     val latitude: Double,
     @Schema(description = "경도", example = "126.977969")

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/trashspot/response/TrashSpotImageResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/trashspot/response/TrashSpotImageResponse.kt
@@ -13,7 +13,7 @@ data class TrashSpotImageResponse(
     val imageUrl: String,
 ) {
     companion object {
-        fun of(trashSpotImage: TrashSpotImage) =
+        fun of(trashSpotImage: TrashSpotImage.Info) =
             TrashSpotImageResponse(
                 imageId = trashSpotImage.id,
                 trashSpotId = trashSpotImage.trashSpotId,

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/trashspot/response/TrashSpotResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/trashspot/response/TrashSpotResponse.kt
@@ -34,7 +34,7 @@ data class TrashSpotResponse(
     val updatedAt: LocalDateTime?,
 ) {
     companion object {
-        fun of(trashSpot: TrashSpot) =
+        fun of(trashSpot: TrashSpot.Info) =
             TrashSpotResponse(
                 id = trashSpot.id,
                 name = trashSpot.name,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/common/GeoConverter.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/common/GeoConverter.kt
@@ -1,0 +1,18 @@
+package com.sseudam.common
+
+import com.sseudam.support.geo.GeoJson
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.springframework.stereotype.Component
+
+@Component
+class GeoConverter {
+    companion object {
+        private val GEOMETRY_FACTORY = GeometryFactory()
+    }
+
+    fun geoJsonPointToJtsPoint(point: GeoJson.Point): org.locationtech.jts.geom.Point {
+        val coordinate = Coordinate(point.coordinates[0], point.coordinates[1])
+        return GEOMETRY_FACTORY.createPoint(coordinate)
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestion.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestion.kt
@@ -10,6 +10,7 @@ class SpotSuggestion {
     /**
      * SpotSuggestion Create
      * @property userId 제보자 id
+     * @property spotName 쓰레기통 이름
      * @property latitude 제보 위치 위도
      * @property longitude 제보 위치 경도
      * @property region 제보 지역
@@ -19,6 +20,7 @@ class SpotSuggestion {
      */
     data class Create(
         val userId: Long,
+        val spotName: String,
         val latitude: Double,
         val longitude: Double,
         val region: Region,
@@ -31,6 +33,7 @@ class SpotSuggestion {
      * SpotSuggestion Info
      * @property id 제보 id
      * @property userId 제보자 id
+     * @property spotName 쓰레기통 이름
      * @property point 제보 위치
      * @property region 제보 지역
      * @property address 제보 주소
@@ -42,6 +45,7 @@ class SpotSuggestion {
     data class Info(
         val id: Long,
         val userId: Long,
+        val spotName: String,
         val point: GeoJson,
         val region: Region,
         val address: Address,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestionRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestionRepository.kt
@@ -20,4 +20,9 @@ interface SpotSuggestionRepository {
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
     ): List<SpotSuggestion.Info>
+
+    fun update(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionEventListener.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionEventListener.kt
@@ -1,0 +1,29 @@
+package com.sseudam.suggestion
+
+import com.sseudam.suggestion.event.SuggestionUpdateEvent
+import com.sseudam.trashspot.TrashSpotService
+import com.sseudam.trashspot.image.TrashSpotImage
+import com.sseudam.trashspot.image.TrashSpotImageService
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class SuggestionEventListener(
+    private val trashSpotService: TrashSpotService,
+    private val trashSpotImageService: TrashSpotImageService,
+) {
+    @Async
+    @EventListener
+    fun createSuggestionListener(event: SuggestionUpdateEvent) {
+        val trashSpot = trashSpotService.createTrashSpotBySuggestion(event.suggestion)
+        trashSpotImageService.append(
+            TrashSpotImage.Create(
+                trashSpot.id,
+                event.suggestion.imageUrl,
+            ),
+        )
+    }
+
+    // TODO: Update Suggestion Notification
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -2,6 +2,7 @@ package com.sseudam.suggestion
 
 import com.sseudam.common.ImageS3Caller
 import com.sseudam.common.S3ImageUrl
+import com.sseudam.suggestion.event.SuggestionEventPublisher
 import com.sseudam.support.cursor.OffsetPageRequest
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -10,6 +11,8 @@ import java.time.LocalDateTime
 class SuggestionService(
     private val suggestionAppender: SuggestionAppender,
     private val suggestionReader: SuggestionReader,
+    private val suggestionUpdater: SuggestionUpdater,
+    private val suggestionEventPublisher: SuggestionEventPublisher,
     private val imageS3Caller: ImageS3Caller,
 ) {
     companion object {
@@ -37,4 +40,13 @@ class SuggestionService(
     ): List<SpotSuggestion.Info> = suggestionReader.readAllBy(offsetPageRequest, searchStatus)
 
     fun findSpotSuggestionById(suggestionId: Long): SpotSuggestion.Info = suggestionReader.readBy(suggestionId)
+
+    fun updateSuggestion(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info {
+        val suggestion = suggestionUpdater.update(suggestionId, status)
+        suggestionEventPublisher.publish(suggestion)
+        return suggestion
+    }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionUpdater.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionUpdater.kt
@@ -5,4 +5,9 @@ import org.springframework.stereotype.Component
 @Component
 class SuggestionUpdater(
     private val spotSuggestionRepository: SpotSuggestionRepository,
-)
+) {
+    fun update(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info = spotSuggestionRepository.update(suggestionId, status)
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/event/SuggestionEventPublisher.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/event/SuggestionEventPublisher.kt
@@ -1,0 +1,18 @@
+package com.sseudam.suggestion.event
+
+import com.sseudam.suggestion.SpotSuggestion
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class SuggestionEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    fun publish(suggestion: SpotSuggestion.Info) {
+        applicationEventPublisher.publishEvent(
+            SuggestionUpdateEvent(
+                suggestion,
+            ),
+        )
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/event/SuggestionUpdateEvent.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/event/SuggestionUpdateEvent.kt
@@ -1,0 +1,7 @@
+package com.sseudam.suggestion.event
+
+import com.sseudam.suggestion.SpotSuggestion
+
+data class SuggestionUpdateEvent(
+    val suggestion: SpotSuggestion.Info,
+)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpot.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpot.kt
@@ -3,23 +3,40 @@ package com.sseudam.trashspot
 import com.sseudam.common.Address
 import com.sseudam.support.geo.GeoJson
 import com.sseudam.support.geo.Region
+import org.locationtech.jts.geom.Point
 import java.time.LocalDateTime
 
-/**
- * TrashSpot
- * @property id 쓰레기통 id
- * @property name 쓰레기통 정보
- * @property region 쓰레기통 지역
- * @property address 쓰레기통 주소
- * @property point 쓰레기통 위치
- * @property trashType 쓰레기통 타입
- */
-data class TrashSpot(
-    val id: Long,
-    val name: String,
-    val region: Region,
-    val address: Address,
-    val point: GeoJson,
-    val trashType: TrashType,
-    val updatedAt: LocalDateTime? = null,
-)
+class TrashSpot {
+    /** TrashSpot Create
+     * @property name 쓰레기통 정보
+     * @property region 쓰레기통 지역
+     * @property address 쓰레기통 주소
+     * @property point 쓰레기통 위치
+     * @property trashType 쓰레기통 타입
+     */
+    data class Create(
+        val name: String,
+        val region: Region,
+        val address: Address,
+        val point: Point,
+        val trashType: TrashType,
+    )
+
+    /** TrashSpot Info
+     * @property id 쓰레기통 id
+     * @property name 쓰레기통 정보
+     * @property region 쓰레기통 지역
+     * @property address 쓰레기통 주소
+     * @property point 쓰레기통 위치
+     * @property trashType 쓰레기통 타입
+     */
+    data class Info(
+        val id: Long,
+        val name: String,
+        val region: Region,
+        val address: Address,
+        val point: GeoJson,
+        val trashType: TrashType,
+        val updatedAt: LocalDateTime? = null,
+    )
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotAppender.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotAppender.kt
@@ -1,0 +1,10 @@
+package com.sseudam.trashspot
+
+import org.springframework.stereotype.Component
+
+@Component
+class TrashSpotAppender(
+    private val trashSpotRepository: TrashSpotRepository,
+) {
+    fun append(createTrashSpot: TrashSpot.Create): TrashSpot.Info = trashSpotRepository.save(createTrashSpot)
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotDetail.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotDetail.kt
@@ -4,7 +4,7 @@ import com.sseudam.trashspot.image.TrashSpotImage
 import com.sseudam.user.UserProfile
 
 data class TrashSpotDetail(
-    val trashSpot: TrashSpot,
-    val image: TrashSpotImage?,
+    val trashSpot: TrashSpot.Info,
+    val image: TrashSpotImage.Info?,
     val user: UserProfile?,
 )

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
@@ -17,7 +17,7 @@ class TrashSpotFacade(
         region: Region?,
         trashType: TrashType?,
         location: TrashSpotLocation,
-    ): List<TrashSpot> {
+    ): List<TrashSpot.Info> {
         val trashSpots = trashSpotService.findAll(region, trashType, location)
         return trashSpots
     }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotReader.kt
@@ -17,32 +17,32 @@ class TrashSpotReader(
         Cache.cache(
             ttl = 360,
             key = ALL_SPOT,
-            typeReference = object : TypeReference<List<TrashSpot>>() {},
+            typeReference = object : TypeReference<List<TrashSpot.Info>>() {},
         ) {
             trashSpotRepository.findAll()
         }
 
-    fun readAllByRegion(region: Region): List<TrashSpot> =
+    fun readAllByRegion(region: Region): List<TrashSpot.Info> =
         Cache.cache(
             ttl = 360,
             key = "$ALL_SPOT:${region.name}",
-            typeReference = object : TypeReference<List<TrashSpot>>() {},
+            typeReference = object : TypeReference<List<TrashSpot.Info>>() {},
         ) {
             trashSpotRepository.findAllByRegion(region)
         }
 
-    fun readAllByLocation(location: TrashSpotLocation): List<TrashSpot> = trashSpotRepository.findAllByLocation(location)
+    fun readAllByLocation(location: TrashSpotLocation): List<TrashSpot.Info> = trashSpotRepository.findAllByLocation(location)
 
     fun readAllByLocationAndRegion(
         region: Region,
         location: TrashSpotLocation,
-    ): List<TrashSpot> = trashSpotRepository.findAllByLocationAndRegion(region, location)
+    ): List<TrashSpot.Info> = trashSpotRepository.findAllByLocationAndRegion(region, location)
 
-    fun readAllByType(type: TrashType): List<TrashSpot> =
+    fun readAllByType(type: TrashType): List<TrashSpot.Info> =
         Cache.cache(
             ttl = 360,
             key = "$ALL_SPOT:${type.name}",
-            typeReference = object : TypeReference<List<TrashSpot>>() {},
+            typeReference = object : TypeReference<List<TrashSpot.Info>>() {},
         ) {
             trashSpotRepository.findAllByType(type)
         }
@@ -50,9 +50,9 @@ class TrashSpotReader(
     fun readAllByLocationAndType(
         location: TrashSpotLocation,
         type: TrashType,
-    ): List<TrashSpot> = trashSpotRepository.findAllByLocationAndType(location, type)
+    ): List<TrashSpot.Info> = trashSpotRepository.findAllByLocationAndType(location, type)
 
-    fun findByCondition(condition: FindTrashSpotPolicyCondition): List<TrashSpot> =
+    fun findByCondition(condition: FindTrashSpotPolicyCondition): List<TrashSpot.Info> =
         when (condition) {
             FindTrashSpotPolicyCondition.All -> readAll()
             is FindTrashSpotPolicyCondition.ByRegion -> readAllByRegion(condition.region)
@@ -62,7 +62,7 @@ class TrashSpotReader(
             is FindTrashSpotPolicyCondition.ByTypeAndLocation -> readAllByLocationAndType(condition.location, condition.type)
         }
 
-    fun readBy(spotId: Long): TrashSpot = trashSpotRepository.findById(spotId)
+    fun readBy(spotId: Long): TrashSpot.Info = trashSpotRepository.findById(spotId)
 
-    fun readAllByIds(spotIds: List<Long>): List<TrashSpot> = trashSpotRepository.findAllByIds(spotIds)
+    fun readAllByIds(spotIds: List<Long>): List<TrashSpot.Info> = trashSpotRepository.findAllByIds(spotIds)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotRepository.kt
@@ -3,25 +3,27 @@ package com.sseudam.trashspot
 import com.sseudam.support.geo.Region
 
 interface TrashSpotRepository {
-    fun findAll(): List<TrashSpot>
+    fun save(createTrashSpot: TrashSpot.Create): TrashSpot.Info
 
-    fun findAllByRegion(region: Region): List<TrashSpot>
+    fun findAll(): List<TrashSpot.Info>
 
-    fun findAllByLocation(location: TrashSpotLocation): List<TrashSpot>
+    fun findAllByRegion(region: Region): List<TrashSpot.Info>
+
+    fun findAllByLocation(location: TrashSpotLocation): List<TrashSpot.Info>
 
     fun findAllByLocationAndRegion(
         region: Region,
         location: TrashSpotLocation,
-    ): List<TrashSpot>
+    ): List<TrashSpot.Info>
 
-    fun findAllByType(type: TrashType): List<TrashSpot>
+    fun findAllByType(type: TrashType): List<TrashSpot.Info>
 
     fun findAllByLocationAndType(
         location: TrashSpotLocation,
         type: TrashType,
-    ): List<TrashSpot>
+    ): List<TrashSpot.Info>
 
-    fun findById(spotId: Long): TrashSpot
+    fun findById(spotId: Long): TrashSpot.Info
 
-    fun findAllByIds(spotIds: List<Long>): List<TrashSpot>
+    fun findAllByIds(spotIds: List<Long>): List<TrashSpot.Info>
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
@@ -1,17 +1,33 @@
 package com.sseudam.trashspot
 
+import com.sseudam.common.GeoConverter
+import com.sseudam.suggestion.SpotSuggestion
+import com.sseudam.support.geo.GeoJson
 import com.sseudam.support.geo.Region
 import org.springframework.stereotype.Service
 
 @Service
 class TrashSpotService(
     private val trashSpotReader: TrashSpotReader,
+    private val trashSpotAppender: TrashSpotAppender,
+    private val geoConverter: GeoConverter,
 ) {
+    fun createTrashSpotBySuggestion(suggestionInfo: SpotSuggestion.Info): TrashSpot.Info =
+        trashSpotAppender.append(
+            TrashSpot.Create(
+                name = suggestionInfo.spotName,
+                region = suggestionInfo.region,
+                trashType = suggestionInfo.trashType,
+                address = suggestionInfo.address,
+                point = geoConverter.geoJsonPointToJtsPoint(suggestionInfo.point as GeoJson.Point),
+            ),
+        )
+
     fun findAll(
         region: Region?,
         trashType: TrashType?,
         location: TrashSpotLocation,
-    ): List<TrashSpot> {
+    ): List<TrashSpot.Info> {
         val condition =
             when {
                 location.isNotSet() && trashType != null -> FindTrashSpotPolicyCondition.ByTypeAndLocation(trashType, location)
@@ -24,7 +40,7 @@ class TrashSpotService(
         return trashSpotReader.findByCondition(condition)
     }
 
-    fun findOne(spotId: Long): TrashSpot = trashSpotReader.readBy(spotId)
+    fun findOne(spotId: Long): TrashSpot.Info = trashSpotReader.readBy(spotId)
 
-    fun findAllByIds(spotIds: List<Long>): List<TrashSpot> = trashSpotReader.readAllByIds(spotIds)
+    fun findAllByIds(spotIds: List<Long>): List<TrashSpot.Info> = trashSpotReader.readAllByIds(spotIds)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImage.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImage.kt
@@ -1,13 +1,23 @@
 package com.sseudam.trashspot.image
 
-/**
- * TrashSpotImage
- * @property id 이미지 id
- * @property trashSpotId 쓰레기통 id
- * @property imageUrl 이미지 url
- */
-data class TrashSpotImage(
-    val id: Long,
-    val trashSpotId: Long,
-    val imageUrl: String,
-)
+class TrashSpotImage {
+    /** TrashSpotImage Create
+     * @property trashSpotId 쓰레기통 id
+     * @property imageUrl 이미지 url
+     */
+    data class Create(
+        val trashSpotId: Long,
+        val imageUrl: String,
+    )
+
+    /** TrashSpotImage Info
+     * @property id 이미지 id
+     * @property trashSpotId 쓰레기통 id
+     * @property imageUrl 이미지 url
+     */
+    data class Info(
+        val id: Long,
+        val trashSpotId: Long,
+        val imageUrl: String,
+    )
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageAppender.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageAppender.kt
@@ -1,0 +1,10 @@
+package com.sseudam.trashspot.image
+
+import org.springframework.stereotype.Component
+
+@Component
+class TrashSpotImageAppender(
+    private val trashSpotImageRepository: TrashSpotImageRepository,
+) {
+    fun append(createImage: TrashSpotImage.Create): TrashSpotImage.Info = trashSpotImageRepository.save(createImage)
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageReader.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 class TrashSpotImageReader(
     private val trashSpotImageRepository: TrashSpotImageRepository,
 ) {
-    fun readAllByTrashSpotIds(map: List<Long>): List<TrashSpotImage> = trashSpotImageRepository.findAllByTrashSpotIds(map)
+    fun readAllByTrashSpotIds(map: List<Long>): List<TrashSpotImage.Info> = trashSpotImageRepository.findAllByTrashSpotIds(map)
 
-    fun readBySpotId(spotId: Long): List<TrashSpotImage> = trashSpotImageRepository.findBySpotId(spotId)
+    fun readBySpotId(spotId: Long): List<TrashSpotImage.Info> = trashSpotImageRepository.findBySpotId(spotId)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageRepository.kt
@@ -1,7 +1,9 @@
 package com.sseudam.trashspot.image
 
 interface TrashSpotImageRepository {
-    fun findAllByTrashSpotIds(map: List<Long>): List<TrashSpotImage>
+    fun save(createImage: TrashSpotImage.Create): TrashSpotImage.Info
 
-    fun findBySpotId(spotId: Long): List<TrashSpotImage>
+    fun findAllByTrashSpotIds(map: List<Long>): List<TrashSpotImage.Info>
+
+    fun findBySpotId(spotId: Long): List<TrashSpotImage.Info>
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImageService.kt
@@ -6,8 +6,16 @@ import org.springframework.stereotype.Service
 @Service
 class TrashSpotImageService(
     private val trashSpotImageReader: TrashSpotImageReader,
+    private val trashSpotImageAppender: TrashSpotImageAppender,
 ) {
-    fun findAll(trashSpots: List<TrashSpot>): List<TrashSpotImage> = trashSpotImageReader.readAllByTrashSpotIds(trashSpots.map { it.id })
+    fun append(createImage: TrashSpotImage.Create): TrashSpotImage.Info = trashSpotImageAppender.append(createImage)
 
-    fun findBySpotId(spotId: Long): List<TrashSpotImage> = trashSpotImageReader.readBySpotId(spotId)
+    fun findAll(trashSpots: List<TrashSpot.Info>): List<TrashSpotImage.Info> =
+        trashSpotImageReader.readAllByTrashSpotIds(
+            trashSpots.map {
+                it.id
+            },
+        )
+
+    fun findBySpotId(spotId: Long): List<TrashSpotImage.Info> = trashSpotImageReader.readBySpotId(spotId)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedAll.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedAll.kt
@@ -8,7 +8,7 @@ data class SpotVisitedAll(
     companion object {
         fun of(
             spotVisited: List<SpotVisited.Info>,
-            spots: List<TrashSpot>,
+            spots: List<TrashSpot.Info>,
         ): SpotVisitedAll {
             val spotsMap = spots.associateBy { it.id }
 

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
@@ -55,4 +55,13 @@ class SpotSuggestionCoreRepository(
         txAdvice.readOnly {
             spotSuggestionCustomRepository.findAllBy(offsetPageRequest, searchStatus)
         }
+
+    override fun update(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info =
+        txAdvice.write {
+            val suggestion = spotSuggestionJpaRepository.findByIdOrElseThrow(suggestionId)
+            return@write suggestion.updateStatus(status).toSpotSuggestion()
+        }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
@@ -18,6 +18,8 @@ import org.locationtech.jts.geom.Point
 @Table(name = "t_spot_suggestion")
 class SpotSuggestionEntity(
     val userId: Long,
+    @Column(columnDefinition = "varchar(50)")
+    val spotName: String,
     @Column(columnDefinition = "geometry(Point, 4326)")
     val point: Point,
     @Enumerated(value = EnumType.STRING)
@@ -30,7 +32,7 @@ class SpotSuggestionEntity(
     val imageUrl: String,
     @Enumerated(value = EnumType.STRING)
     @Column(columnDefinition = "varchar(15)")
-    val status: SuggestionStatus,
+    var status: SuggestionStatus,
 ) : BaseEntity() {
     constructor(
         imageUrl: String,
@@ -38,6 +40,7 @@ class SpotSuggestionEntity(
         createSpotSuggestion: SpotSuggestion.Create,
     ) : this(
         userId = createSpotSuggestion.userId,
+        spotName = createSpotSuggestion.spotName,
         point = point,
         region = createSpotSuggestion.region,
         address =
@@ -54,6 +57,7 @@ class SpotSuggestionEntity(
         SpotSuggestion.Info(
             id = id!!,
             userId = userId,
+            spotName = spotName,
             point = GeoJson.Point(listOf(point.x, point.y)),
             region = region,
             address = address,
@@ -62,4 +66,9 @@ class SpotSuggestionEntity(
             imageUrl = imageUrl,
             createdAt = createdAt,
         )
+
+    fun updateStatus(status: SuggestionStatus): SpotSuggestionEntity {
+        this.status = status
+        return this
+    }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotCoreRepository.kt
@@ -14,21 +14,29 @@ class TrashSpotCoreRepository(
     private val trashSpotJpaRepository: TrashSpotJpaRepository,
     private val txAdvice: TxAdvice,
 ) : TrashSpotRepository {
-    override fun findAll(): List<TrashSpot> =
+    override fun save(createTrashSpot: TrashSpot.Create): TrashSpot.Info =
+        txAdvice.write {
+            trashSpotJpaRepository
+                .save(
+                    TrashSpotEntity(createTrashSpot),
+                ).toTrashSpot()
+        }
+
+    override fun findAll(): List<TrashSpot.Info> =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findAll()
                 .map { it.toTrashSpot() }
         }
 
-    override fun findAllByRegion(region: Region): List<TrashSpot> =
+    override fun findAllByRegion(region: Region): List<TrashSpot.Info> =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findAllByRegion(region)
                 .map { it.toTrashSpot() }
         }
 
-    override fun findAllByLocation(location: TrashSpotLocation): List<TrashSpot> =
+    override fun findAllByLocation(location: TrashSpotLocation): List<TrashSpot.Info> =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findAllByLocation(
@@ -42,7 +50,7 @@ class TrashSpotCoreRepository(
     override fun findAllByLocationAndRegion(
         region: Region,
         location: TrashSpotLocation,
-    ): List<TrashSpot> =
+    ): List<TrashSpot.Info> =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findAllByLocationAndRegion(
@@ -54,7 +62,7 @@ class TrashSpotCoreRepository(
                 ).map { it.toTrashSpot() }
         }
 
-    override fun findAllByType(type: TrashType): List<TrashSpot> =
+    override fun findAllByType(type: TrashType): List<TrashSpot.Info> =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findAllByTrashType(type)
@@ -64,7 +72,7 @@ class TrashSpotCoreRepository(
     override fun findAllByLocationAndType(
         location: TrashSpotLocation,
         type: TrashType,
-    ): List<TrashSpot> =
+    ): List<TrashSpot.Info> =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findAllByLocationAndType(
@@ -76,14 +84,14 @@ class TrashSpotCoreRepository(
                 ).map { it.toTrashSpot() }
         }
 
-    override fun findById(spotId: Long): TrashSpot =
+    override fun findById(spotId: Long): TrashSpot.Info =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findByIdOrElseThrow(spotId)
                 .toTrashSpot()
         }
 
-    override fun findAllByIds(spotIds: List<Long>): List<TrashSpot> =
+    override fun findAllByIds(spotIds: List<Long>): List<TrashSpot.Info> =
         txAdvice.readOnly {
             trashSpotJpaRepository
                 .findAllByIdIn(spotIds)

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotEntity.kt
@@ -30,8 +30,16 @@ class TrashSpotEntity(
     @Column(columnDefinition = "varchar(20)")
     val trashType: TrashType,
 ) : BaseEntity() {
-    fun toTrashSpot(): TrashSpot =
-        TrashSpot(
+    constructor(createTrashSpot: TrashSpot.Create) : this(
+        name = createTrashSpot.name,
+        region = createTrashSpot.region,
+        address = createTrashSpot.address,
+        point = createTrashSpot.point,
+        trashType = createTrashSpot.trashType,
+    )
+
+    fun toTrashSpot(): TrashSpot.Info =
+        TrashSpot.Info(
             id = id!!,
             name = name,
             region = region,

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/image/TrashSpotImageCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/image/TrashSpotImageCoreRepository.kt
@@ -10,14 +10,22 @@ class TrashSpotImageCoreRepository(
     private val trashSpotImageJpaRepository: TrashSpotImageJpaRepository,
     private val txAdvice: TxAdvice,
 ) : TrashSpotImageRepository {
-    override fun findAllByTrashSpotIds(map: List<Long>): List<TrashSpotImage> =
+    override fun save(createImage: TrashSpotImage.Create): TrashSpotImage.Info =
+        txAdvice.write {
+            trashSpotImageJpaRepository
+                .save(
+                    TrashSpotImageEntity(createImage),
+                ).toTrashSpotImage()
+        }
+
+    override fun findAllByTrashSpotIds(map: List<Long>): List<TrashSpotImage.Info> =
         txAdvice.readOnly {
             trashSpotImageJpaRepository
                 .findAllByTrashSpotIdIn(map)
                 .map { it.toTrashSpotImage() }
         }
 
-    override fun findBySpotId(spotId: Long): List<TrashSpotImage> =
+    override fun findBySpotId(spotId: Long): List<TrashSpotImage.Info> =
         txAdvice.readOnly {
             trashSpotImageJpaRepository
                 .findAllByTrashSpotId(spotId)

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/image/TrashSpotImageEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/image/TrashSpotImageEntity.kt
@@ -11,8 +11,13 @@ class TrashSpotImageEntity(
     val trashSpotId: Long,
     val imageUrl: String,
 ) : BaseEntity() {
-    fun toTrashSpotImage(): TrashSpotImage =
-        TrashSpotImage(
+    constructor(createTrashSpotImage: TrashSpotImage.Create) : this(
+        createTrashSpotImage.trashSpotId,
+        createTrashSpotImage.imageUrl,
+    )
+
+    fun toTrashSpotImage(): TrashSpotImage.Info =
+        TrashSpotImage.Info(
             id = id!!,
             trashSpotId = trashSpotId,
             imageUrl = imageUrl,


### PR DESCRIPTION
## 🌱 관련 이슈
- close #65 

## 📌 작업 내용 및 특이 사항

- 83f9f25aff6da44bdfdc6e2e856e0f1103e9b014: 제보 내역 반영

## 📝 참고

- 제보된 데이터로 장소 추가

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ability for admins to update the status of suggestions via a new endpoint.
  - Introduced support for including a trash bin name ("spotName") when creating a suggestion.
  - Suggestions can now trigger creation of new trash spots and associated images upon status update.

- **Enhancements**
  - Trash spot and image data structures now distinguish between creation and info details for clearer data handling.
  - Improved event-driven handling for suggestion updates, enabling asynchronous processing.
  - Various API responses and request types now use more specific and informative data representations.

- **Bug Fixes**
  - The "name" column in admin data is now allowed to be nullable.

- **Refactor**
  - Streamlined and clarified internal data flows for trash spot, image, and suggestion management.
  - Adjusted return types across APIs to use more precise info objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->