### PR TITLE
[Feature] Read Admin user visitedSpot

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -48,6 +48,8 @@ class AdminFacade(
         val profile = userService.getProfile(userId)
         val visitedByUser = spotVisitedService.findAllByUser(userId)
 
+        if (visitedByUser.isEmpty()) return AdminUserProfile.of(profile, emptyList())
+
         val spotIds = visitedByUser.map { it.spotId }
         val trashSpots = trashSpotService.findAllByIds(spotIds)
 

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -12,6 +12,7 @@ import com.sseudam.suggestion.SuggestionStatus
 import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
+import com.sseudam.trashspot.TrashSpotService
 import com.sseudam.user.UserProfile
 import com.sseudam.user.UserService
 import com.sseudam.visit.SpotVisitedService
@@ -26,6 +27,7 @@ class AdminFacade(
     private val suggestionService: SuggestionService,
     private val reportService: ReportService,
     private val spotVisitedService: SpotVisitedService,
+    private val trashSpotService: TrashSpotService,
     private val passwordEncoder: PasswordEncoder,
 ) {
     fun login(
@@ -45,7 +47,11 @@ class AdminFacade(
     fun findByUser(userId: Long): AdminUserProfile {
         val profile = userService.getProfile(userId)
         val visitedByUser = spotVisitedService.findAllByUser(userId)
-        return AdminUserProfile.of(profile, visitedByUser)
+
+        val spotIds = visitedByUser.map { it.spotId }
+        val trashSpots = trashSpotService.findAllByIds(spotIds)
+
+        return AdminUserProfile.of(profile, trashSpots)
     }
 
     fun findUsers(offsetPageRequest: OffsetPageRequest): List<UserProfile> = userService.findUserProfileBy(offsetPageRequest)

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -1,6 +1,7 @@
 package com.sseudam.admin.application
 
 import com.sseudam.admin.domain.AdminToken
+import com.sseudam.admin.domain.AdminUserProfile
 import com.sseudam.auth.AuthenticationService
 import com.sseudam.report.ReportService
 import com.sseudam.report.ReportType
@@ -13,6 +14,7 @@ import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
 import com.sseudam.user.UserProfile
 import com.sseudam.user.UserService
+import com.sseudam.visit.SpotVisitedService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
@@ -23,6 +25,7 @@ class AdminFacade(
     private val authService: AuthenticationService,
     private val suggestionService: SuggestionService,
     private val reportService: ReportService,
+    private val spotVisitedService: SpotVisitedService,
     private val passwordEncoder: PasswordEncoder,
 ) {
     fun login(
@@ -39,7 +42,11 @@ class AdminFacade(
         return AdminToken(token.accessToken, token.refreshToken)
     }
 
-    fun findOneUser(userId: Long): UserProfile = userService.getProfile(userId)
+    fun findByUser(userId: Long): AdminUserProfile {
+        val profile = userService.getProfile(userId)
+        val visitedByUser = spotVisitedService.findAllByUser(userId)
+        return AdminUserProfile.of(profile, visitedByUser)
+    }
 
     fun findUsers(offsetPageRequest: OffsetPageRequest): List<UserProfile> = userService.findUserProfileBy(offsetPageRequest)
 

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminUserProfile.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminUserProfile.kt
@@ -1,7 +1,7 @@
 package com.sseudam.admin.domain
 
+import com.sseudam.trashspot.TrashSpot
 import com.sseudam.user.UserProfile
-import com.sseudam.visit.SpotVisited
 import java.time.LocalDateTime
 
 data class AdminUserProfile(
@@ -11,12 +11,12 @@ data class AdminUserProfile(
     val name: String?,
     val nickname: String,
     val createdAt: LocalDateTime,
-    val visited: MutableList<SpotVisited.Info>,
+    val visitedSpot: MutableList<TrashSpot.Info>,
 ) {
     companion object {
         fun of(
             profile: UserProfile,
-            visited: List<SpotVisited.Info>,
+            visited: List<TrashSpot.Info>,
         ): AdminUserProfile =
             AdminUserProfile(
                 id = profile.id,
@@ -25,7 +25,7 @@ data class AdminUserProfile(
                 name = profile.name,
                 nickname = profile.nickname,
                 createdAt = profile.createdAt,
-                visited = visited.toMutableList(),
+                visitedSpot = visited.toMutableList(),
             )
     }
 }

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminUserProfile.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminUserProfile.kt
@@ -11,12 +11,12 @@ data class AdminUserProfile(
     val name: String?,
     val nickname: String,
     val createdAt: LocalDateTime,
-    val visitedSpot: MutableList<TrashSpot.Info>,
+    val visitedSpot: List<TrashSpot.Info>,
 ) {
     companion object {
         fun of(
             profile: UserProfile,
-            visited: List<TrashSpot.Info>,
+            visitedSpot: List<TrashSpot.Info>,
         ): AdminUserProfile =
             AdminUserProfile(
                 id = profile.id,
@@ -25,7 +25,7 @@ data class AdminUserProfile(
                 name = profile.name,
                 nickname = profile.nickname,
                 createdAt = profile.createdAt,
-                visitedSpot = visited.toMutableList(),
+                visitedSpot = visitedSpot,
             )
     }
 }

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminUserProfile.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminUserProfile.kt
@@ -1,0 +1,31 @@
+package com.sseudam.admin.domain
+
+import com.sseudam.user.UserProfile
+import com.sseudam.visit.SpotVisited
+import java.time.LocalDateTime
+
+data class AdminUserProfile(
+    val id: Long,
+    val key: String,
+    val email: String,
+    val name: String?,
+    val nickname: String,
+    val createdAt: LocalDateTime,
+    val visited: MutableList<SpotVisited.Info>,
+) {
+    companion object {
+        fun of(
+            profile: UserProfile,
+            visited: List<SpotVisited.Info>,
+        ): AdminUserProfile =
+            AdminUserProfile(
+                id = profile.id,
+                key = profile.key,
+                email = profile.email,
+                name = profile.name,
+                nickname = profile.nickname,
+                createdAt = profile.createdAt,
+                visited = visited.toMutableList(),
+            )
+    }
+}

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
@@ -7,6 +7,7 @@ import com.sseudam.admin.presentation.response.report.SpotReportAllResponse
 import com.sseudam.admin.presentation.response.report.SpotReportResponse
 import com.sseudam.admin.presentation.response.suggestion.SpotSuggestionAllResponse
 import com.sseudam.admin.presentation.response.suggestion.SpotSuggestionResponse
+import com.sseudam.admin.presentation.response.user.AdminUserResponse
 import com.sseudam.admin.presentation.response.user.UserAllResponse
 import com.sseudam.admin.presentation.response.user.UserResponse
 import com.sseudam.report.ReportType
@@ -53,7 +54,7 @@ class AdminController(
     @GetMapping("/users/{userId}")
     fun findOneUser(
         @PathVariable("userId") userId: Long,
-    ): UserResponse = UserResponse.of(adminFacade.findOneUser(userId))
+    ): AdminUserResponse = AdminUserResponse.of(adminFacade.findByUser(userId))
 
     /** 어드민 제보 API */
     @Operation(summary = "제보 리스트 조회", description = "제보 리스트를 조회합니다.")

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/user/AdminUserResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/user/AdminUserResponse.kt
@@ -1,7 +1,7 @@
 package com.sseudam.admin.presentation.response.user
 
 import com.sseudam.admin.domain.AdminUserProfile
-import com.sseudam.visit.SpotVisited
+import com.sseudam.trashspot.TrashSpot
 import java.time.LocalDateTime
 
 data class AdminUserResponse(
@@ -9,7 +9,7 @@ data class AdminUserResponse(
     val email: String,
     val nickname: String,
     val createdAt: LocalDateTime,
-    val visited: MutableList<SpotVisited.Info>,
+    val visitedSpot: MutableList<TrashSpot.Info>,
 ) {
     companion object {
         fun of(user: AdminUserProfile): AdminUserResponse =
@@ -18,7 +18,7 @@ data class AdminUserResponse(
                 email = user.email,
                 nickname = user.nickname,
                 createdAt = user.createdAt,
-                visited = user.visited,
+                visitedSpot = user.visitedSpot,
             )
     }
 }

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/user/AdminUserResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/user/AdminUserResponse.kt
@@ -9,7 +9,7 @@ data class AdminUserResponse(
     val email: String,
     val nickname: String,
     val createdAt: LocalDateTime,
-    val visitedSpot: MutableList<TrashSpot.Info>,
+    val visitedSpot: List<TrashSpot.Info>,
 ) {
     companion object {
         fun of(user: AdminUserProfile): AdminUserResponse =

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/user/AdminUserResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/user/AdminUserResponse.kt
@@ -1,0 +1,24 @@
+package com.sseudam.admin.presentation.response.user
+
+import com.sseudam.admin.domain.AdminUserProfile
+import com.sseudam.visit.SpotVisited
+import java.time.LocalDateTime
+
+data class AdminUserResponse(
+    val userId: Long,
+    val email: String,
+    val nickname: String,
+    val createdAt: LocalDateTime,
+    val visited: MutableList<SpotVisited.Info>,
+) {
+    companion object {
+        fun of(user: AdminUserProfile): AdminUserResponse =
+            AdminUserResponse(
+                userId = user.id,
+                email = user.email,
+                nickname = user.nickname,
+                createdAt = user.createdAt,
+                visited = user.visited,
+            )
+    }
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
@@ -35,6 +35,7 @@ class ReportController(
                         reportType = request.reportType,
                         latitude = request.latitude,
                         longitude = request.longitude,
+                        spotName = request.spotName,
                         region = request.region,
                         city = request.city,
                         site = request.site,

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/SpotReportCreateRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/SpotReportCreateRequest.kt
@@ -15,6 +15,8 @@ data class SpotReportCreateRequest(
     val latitude: Double,
     @Schema(description = "경도", example = "126.977969")
     val longitude: Double,
+    @Schema(description = "쓰레기통 이름", example = "우리집앞")
+    val spotName: String,
     @Schema(description = "지역", example = "SEOUL")
     val region: Region,
     @Schema(description = "구/군/시", example = "강남구/거창군/동두천시")

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportType.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportType.kt
@@ -6,4 +6,5 @@ enum class ReportType(
     POINT("쓰레기통 위치"),
     KIND("쓰레기통 종류"),
     PHOTO("쓰레기통 사진"),
+    NAME("쓰레기통 이름"),
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReport.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReport.kt
@@ -13,6 +13,7 @@ class SpotReport {
      * @property reportType 신고 타입
      * @property latitude 제보 위치 위도
      * @property longitude 제보 위치 경도
+     * @property spotName 쓰레기통 이름
      * @property region 제보 지역
      * @property city 제보 지역
      * @property site 제보 주소
@@ -24,6 +25,7 @@ class SpotReport {
         val reportType: ReportType,
         val latitude: Double,
         val longitude: Double,
+        val spotName: String,
         val region: Region,
         val city: String,
         val site: String,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
@@ -23,7 +23,7 @@ class TrashSpotFacade(
     }
 
     fun findDetails(spotId: Long): TrashSpotDetail {
-        val spot = trashSpotService.findOne(spotId)
+        val spot = trashSpotService.findBy(spotId)
         val image = trashSpotImageService.findBySpotId(spotId).lastOrNull()
         val suggestioner = suggestionService.findSpotSuggestionBySite(spot.address.site)
         val user = suggestioner?.let { userService.getProfile(it.userId) }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
@@ -40,7 +40,7 @@ class TrashSpotService(
         return trashSpotReader.findByCondition(condition)
     }
 
-    fun findOne(spotId: Long): TrashSpot.Info = trashSpotReader.readBy(spotId)
+    fun findBy(spotId: Long): TrashSpot.Info = trashSpotReader.readBy(spotId)
 
     fun findAllByIds(spotIds: List<Long>): List<TrashSpot.Info> = trashSpotReader.readAllByIds(spotIds)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisited.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisited.kt
@@ -17,13 +17,13 @@ class SpotVisited {
      * @property userId 방문한 사용자 ID
      * @property spotId 방문한 쓰레기통 장소 ID
      * @property site 방문한 쓰레기통 주소
-     * @property createdAt 방문 시간
+     * @property visitedAt 방문 시간
      */
     data class Info(
         val id: Long,
         val spotId: Long,
         val userId: Long,
         val site: String,
-        val createdAt: LocalDateTime,
+        val visitedAt: LocalDateTime,
     )
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedFacade.kt
@@ -9,7 +9,7 @@ class SpotVisitedFacade(
     private val trashSpotService: TrashSpotService,
 ) {
     fun findSpotVisitedByUserId(userId: Long): SpotVisitedAll {
-        val spotVisited = spotVisitedService.findAll(userId)
+        val spotVisited = spotVisitedService.findAllByUser(userId)
         if (spotVisited.isEmpty()) return SpotVisitedAll(emptyList())
 
         val spotIds = spotVisited.map { it.spotId }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedRepository.kt
@@ -1,7 +1,7 @@
 package com.sseudam.visit
 
 interface SpotVisitedRepository {
-    fun create(spotVisited: SpotVisited.Create)
+    fun create(spotVisited: SpotVisited.Create): SpotVisited.Info
 
     fun readByUserId(userId: Long): List<SpotVisited.Info>
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/visit/SpotVisitedService.kt
@@ -9,5 +9,5 @@ class SpotVisitedService(
 ) {
     fun append(spotVisited: SpotVisited.Create) = spotVisitedAppender.append(spotVisited)
 
-    fun findAll(userId: Long): List<SpotVisited.Info> = spotVisitedReader.readByUserId(userId)
+    fun findAllByUser(userId: Long): List<SpotVisited.Info> = spotVisitedReader.readByUserId(userId)
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
@@ -25,6 +25,8 @@ class SpotReportEntity(
     @Column(columnDefinition = "geometry(Point, 4326)")
     val point: Point,
     val address: Address,
+    @Column(columnDefinition = "varchar(50)")
+    val spotName: String,
     @Enumerated(value = EnumType.STRING)
     @Column(columnDefinition = "varchar(15)")
     val trashType: TrashType,
@@ -47,6 +49,7 @@ class SpotReportEntity(
                 city = createSpotReport.city,
                 site = createSpotReport.site,
             ),
+        spotName = createSpotReport.spotName,
         trashType = createSpotReport.trashType,
         imageUrl = imageUrl,
         status = ReportStatus.WAITING,

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/visit/SpotVisitedCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/visit/SpotVisitedCoreRepository.kt
@@ -10,12 +10,12 @@ class SpotVisitedCoreRepository(
     private val spotVisitedJpaRepository: SpotVisitedJpaRepository,
     private val txAdvice: TxAdvice,
 ) : SpotVisitedRepository {
-    override fun create(spotVisited: SpotVisited.Create): Unit =
+    override fun create(spotVisited: SpotVisited.Create): SpotVisited.Info =
         txAdvice.write {
             spotVisitedJpaRepository
                 .save(
                     SpotVisitedEntity(spotVisited),
-                )
+                ).toSpotVisitedInfo()
         }
 
     override fun readByUserId(userId: Long): List<SpotVisited.Info> =

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/visit/SpotVisitedEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/visit/SpotVisitedEntity.kt
@@ -22,6 +22,6 @@ class SpotVisitedEntity(
             userId = userId,
             spotId = spotId,
             site = "",
-            createdAt = createdAt,
+            visitedAt = createdAt,
         )
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #67 

## 📌 작업 내용 및 특이 사항

- cf1a93cc93d37bb3dad1901d3e885a4d1e28d993: 사용자 방문 기록 조회
- dc1d1857e13363fb5c6eca9117557aa8e2795726: 방문 기록에 따른 방문된 장소 조회

## 📝 참고

- 신고하기 시 쓰레기통 장소를 받도록 잠수함 패치했습니다.

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Admin users can now view enhanced user profiles, including a list of visited trash spots.
  - Added support for reporting trash spots with a specified spot name.

- **Improvements**
  - User visit timestamps are now labeled as "visitedAt" for clarity.
  - New report type added for trash spot names.

- **Bug Fixes**
  - Updated method and property names for consistency and clarity across user and spot visit services.

- **API Changes**
  - Admin user profile and response formats have been updated.
  - Some method signatures and return types have changed for improved data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->