### PR TITLE
[Feature] Read UserPet History

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
@@ -1,10 +1,12 @@
 package com.sseudam.presentation.v1.pet
 
+import com.sseudam.pet.UserPetFacade
 import com.sseudam.pet.UserPetPolicy
 import com.sseudam.pet.UserPetService
 import com.sseudam.presentation.v1.annotation.ApiV1Controller
 import com.sseudam.presentation.v1.pet.request.UpdateUserPetNameRequest
 import com.sseudam.presentation.v1.pet.response.UserPetInfoResponse
+import com.sseudam.presentation.v1.pet.response.UserPetLevelHistoryAllResponse
 import com.sseudam.user.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -16,12 +18,13 @@ import org.springframework.web.bind.annotation.RequestBody
 @ApiV1Controller
 class PetController(
     private val userPetService: UserPetService,
+    private val userPetFacade: UserPetFacade,
     private val userPetPolicy: UserPetPolicy,
 ) {
     @Operation(summary = "펫 정보 조회", description = "사용자의 펫 정보를 조회합니다.")
     @GetMapping("/pets")
     fun findUserPetInfo(user: User): UserPetInfoResponse {
-        val petInfo = userPetService.findPetInfo(user.id)
+        val petInfo = userPetFacade.findPetInfo(user.id)
         val petLevel = userPetPolicy.getLevelType(petInfo.point)
         val maxLevelStandard = userPetPolicy.getMaxLevelStandard(petLevel)
         return UserPetInfoResponse.of(petInfo, petLevel, maxLevelStandard)
@@ -38,5 +41,12 @@ class PetController(
         val petLevel = userPetPolicy.getLevelType(updatedPetInfo.point)
         val maxLevelStandard = userPetPolicy.getMaxLevelStandard(petLevel)
         return UserPetInfoResponse.of(updatedPetInfo, petLevel, maxLevelStandard)
+    }
+
+    @Operation(summary = "현 시즌 펫 성장 기록 조회", description = "사용자의 현 시즌 펫 성장 기록을 조회합니다.")
+    @GetMapping("/pets/season")
+    fun findUserPetSeasonInfo(user: User): UserPetLevelHistoryAllResponse {
+        val histories = userPetFacade.findCurrentSeasonPetHistory(user.id)
+        return UserPetLevelHistoryAllResponse.of(histories)
     }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
@@ -49,4 +49,11 @@ class PetController(
         val histories = userPetFacade.findCurrentSeasonPetHistory(user.id)
         return UserPetLevelHistoryAllResponse.of(histories)
     }
+
+    @Operation(summary = "사용자 전체 펫 성장 기록 조회", description = "사용자의 전체 펫 성장 기록을 조회합니다.")
+    @GetMapping("/pets/history")
+    fun findUserPetHistory(user: User): UserPetLevelHistoryAllResponse {
+        val histories = userPetFacade.findAllPetHistory(user.id)
+        return UserPetLevelHistoryAllResponse.of(histories)
+    }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetInfoResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetInfoResponse.kt
@@ -22,7 +22,7 @@ data class UserPetInfoResponse(
             UserPetInfoResponse(
                 userId = userPetInfo.userId,
                 petId = userPetInfo.petId,
-                nickname = levelType.defaultName,
+                nickname = levelType.adjective + userPetInfo.nickname,
                 point = userPetInfo.point,
                 levelType = levelType,
                 maxLevelStandard = maxLevelStandard,

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryAllResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryAllResponse.kt
@@ -1,0 +1,14 @@
+package com.sseudam.presentation.v1.pet.response
+
+import com.sseudam.pet.UserPetLevelUpHistoryInfo
+
+data class UserPetLevelHistoryAllResponse(
+    val list: List<UserPetLevelHistoryResponse>,
+) {
+    companion object {
+        fun of(histories: List<UserPetLevelUpHistoryInfo>): UserPetLevelHistoryAllResponse =
+            UserPetLevelHistoryAllResponse(
+                list = histories.map { UserPetLevelHistoryResponse.of(it) },
+            )
+    }
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryResponse.kt
@@ -1,0 +1,24 @@
+package com.sseudam.presentation.v1.pet.response
+
+import com.sseudam.pet.Pet
+import com.sseudam.pet.UserPetLevelUpHistoryInfo
+import java.time.LocalDateTime
+
+data class UserPetLevelHistoryResponse(
+    val userId: Long,
+    val nickname: String,
+    val point: Long,
+    val levelType: Pet.LevelType,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun of(history: UserPetLevelUpHistoryInfo): UserPetLevelHistoryResponse =
+            UserPetLevelHistoryResponse(
+                userId = history.userId,
+                nickname = history.nickname,
+                point = history.point,
+                levelType = history.levelType,
+                createdAt = history.createdAt,
+            )
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/LevelStandard.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/LevelStandard.kt
@@ -2,14 +2,14 @@ package com.sseudam.pet
 
 object LevelStandard {
     const val LEVEL_1_MIN = 0
-    const val LEVEL_1_MAX = 20
-    const val LEVEL_2_MIN = 21
-    const val LEVEL_2_MAX = 110
-    const val LEVEL_3_MIN = 111
-    const val LEVEL_3_MAX = 220
-    const val LEVEL_4_MIN = 221
-    const val LEVEL_4_MAX = 300
-    const val SPECIAL_MIN = 301
+    const val LEVEL_1_MAX = 19
+    const val LEVEL_2_MIN = 20
+    const val LEVEL_2_MAX = 109
+    const val LEVEL_3_MIN = 110
+    const val LEVEL_3_MAX = 219
+    const val LEVEL_4_MIN = 220
+    const val LEVEL_4_MAX = 299
+    const val SPECIAL_MIN = 300
 
     val LEVEL_1_RANGE = LEVEL_1_MIN..LEVEL_1_MAX
     val LEVEL_2_RANGE = LEVEL_2_MIN..LEVEL_2_MAX

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/LevelStandard.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/LevelStandard.kt
@@ -9,7 +9,7 @@ object LevelStandard {
     const val LEVEL_3_MAX = 220
     const val LEVEL_4_MIN = 221
     const val LEVEL_4_MAX = 300
-    const val LEVEL_5_MIN = 301
+    const val SPECIAL_MIN = 301
 
     val LEVEL_1_RANGE = LEVEL_1_MIN..LEVEL_1_MAX
     val LEVEL_2_RANGE = LEVEL_2_MIN..LEVEL_2_MAX

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/Pet.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/Pet.kt
@@ -8,6 +8,7 @@ class Pet {
     data class Create(
         val name: String,
         val levelType: LevelType,
+        val year: Int,
         val monthly: Month,
     )
 
@@ -15,18 +16,19 @@ class Pet {
         val id: Long,
         val name: String,
         val levelType: LevelType,
+        val year: Int,
         val monthly: Month,
         val createdAt: LocalDateTime,
     )
 
     enum class LevelType(
         val level: Int,
-        val defaultName: String,
+        val adjective: String,
     ) {
-        LEVEL_1(1, "작고 소중한 냥이"),
-        LEVEL_2(2, "호기심 가득한 냥이"),
-        LEVEL_3(3, "쑥쑥 자라나는 냥이"),
-        LEVEL_4(4, "왕 커서 귀여운 냥이"),
-        LEVEL_5(5, "스페셜 냥이"),
+        LEVEL_1(1, "작고 소중한 "),
+        LEVEL_2(2, "호기심 가득한 "),
+        LEVEL_3(3, "쑥쑥 자라나는 "),
+        LEVEL_4(4, "왕 커서 귀여운 "),
+        SPECIAL(5, "스페셜 "),
     }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetAppender.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetAppender.kt
@@ -1,0 +1,12 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Component
+
+@Component
+class PetAppender(
+    private val petRepository: PetRepository,
+) {
+    fun appendSeasonPet() {
+        // TODO: LastDay Scheduler Append
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistory.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistory.kt
@@ -6,6 +6,7 @@ import java.time.Month
 /** 펫 성장 히스토리 */
 class PetLevelUpHistory {
     data class Create(
+        val userId: Long,
         val userPetId: Long,
         val pointHistoryId: Long,
         val nickname: String,
@@ -16,6 +17,7 @@ class PetLevelUpHistory {
 
     data class Info(
         val id: Long,
+        val userId: Long,
         val userPetId: Long,
         val pointHistoryId: Long,
         val nickname: String,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistory.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistory.kt
@@ -1,17 +1,26 @@
 package com.sseudam.pet
 
 import java.time.LocalDateTime
+import java.time.Month
 
 /** 펫 성장 히스토리 */
 class PetLevelUpHistory {
     data class Create(
         val userPetId: Long,
+        val pointHistoryId: Long,
+        val nickname: String,
+        val year: Int,
+        val monthly: Month,
         val levelType: Pet.LevelType,
     )
 
     data class Info(
         val id: Long,
         val userPetId: Long,
+        val pointHistoryId: Long,
+        val nickname: String,
+        val year: Int,
+        val monthly: Month,
         val levelType: Pet.LevelType,
         val createdAt: LocalDateTime,
         val updatedAt: LocalDateTime?,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryReader.kt
@@ -1,0 +1,20 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Component
+import java.time.Month
+
+@Component
+class PetLevelUpHistoryReader(
+    private val petLevelUpHistoryRepository: PetLevelUpHistoryRepository,
+) {
+    fun readBy(
+        currentYear: Int,
+        currentMonth: Month,
+        userPetId: Long,
+    ): List<PetLevelUpHistory.Info> =
+        petLevelUpHistoryRepository.findAllBy(
+            currentYear = currentYear,
+            currentMonth = currentMonth,
+            userPetId = userPetId,
+        )
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryReader.kt
@@ -17,4 +17,11 @@ class PetLevelUpHistoryReader(
             currentMonth = currentMonth,
             userPetId = userPetId,
         )
+
+    fun readBy(userPetId: Long): List<PetLevelUpHistory.Info> =
+        petLevelUpHistoryRepository.findAllBy(
+            userPetId = userPetId,
+        )
+
+    fun readByUser(userId: Long): List<PetLevelUpHistory.Info> = petLevelUpHistoryRepository.findAllByUserId(userId)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryRepository.kt
@@ -8,4 +8,8 @@ interface PetLevelUpHistoryRepository {
         currentMonth: Month,
         userPetId: Long,
     ): List<PetLevelUpHistory.Info>
+
+    fun findAllBy(userPetId: Long): List<PetLevelUpHistory.Info>
+
+    fun findAllByUserId(userId: Long): List<PetLevelUpHistory.Info>
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryRepository.kt
@@ -1,0 +1,11 @@
+package com.sseudam.pet
+
+import java.time.Month
+
+interface PetLevelUpHistoryRepository {
+    fun findAllBy(
+        currentYear: Int,
+        currentMonth: Month,
+        userPetId: Long,
+    ): List<PetLevelUpHistory.Info>
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryService.kt
@@ -1,0 +1,20 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Service
+import java.time.Month
+
+@Service
+class PetLevelUpHistoryService(
+    private val petLevelUpHistoryReader: PetLevelUpHistoryReader,
+) {
+    fun findAllBy(
+        currentYear: Int,
+        currentMonth: Month,
+        userPetId: Long,
+    ): List<PetLevelUpHistory.Info> =
+        petLevelUpHistoryReader.readBy(
+            currentYear = currentYear,
+            currentMonth = currentMonth,
+            userPetId = userPetId,
+        )
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpHistoryService.kt
@@ -17,4 +17,11 @@ class PetLevelUpHistoryService(
             currentMonth = currentMonth,
             userPetId = userPetId,
         )
+
+    fun findAllBy(userPetId: Long): List<PetLevelUpHistory.Info> =
+        petLevelUpHistoryReader.readBy(
+            userPetId = userPetId,
+        )
+
+    fun findAllByUser(userId: Long): List<PetLevelUpHistory.Info> = petLevelUpHistoryReader.readByUser(userId)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetLevelUpRepository.kt
@@ -1,3 +1,0 @@
-package com.sseudam.pet
-
-interface PetLevelUpRepository

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistory.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistory.kt
@@ -5,18 +5,18 @@ import java.time.LocalDateTime
 /** 펫 포인트 히스토리 */
 class PetPointHistory {
     data class Create(
-        val userId: Long,
-        val petId: Long,
+        val userPetId: Long,
         val event: PointEvent,
-        val point: Long,
+        val previousPoint: Long,
+        val additionalPoint: Long,
     )
 
     data class Info(
         val id: Long,
-        val userId: Long,
-        val petId: Long,
+        val userPetId: Long,
         val event: PointEvent,
-        val point: Long,
+        val previousPoint: Long,
+        val additionalPoint: Long,
         val createdAt: LocalDateTime,
     )
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryAppender.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryAppender.kt
@@ -1,0 +1,8 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Component
+
+@Component
+class PetPointHistoryAppender(
+    private val petPointHistoryRepository: PetPointHistoryRepository,
+)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryReader.kt
@@ -1,0 +1,10 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Component
+
+@Component
+class PetPointHistoryReader(
+    private val petPointHistoryRepository: PetPointHistoryRepository,
+) {
+    fun readAllByUserPet(userPetId: Long): List<PetPointHistory.Info> = petPointHistoryRepository.findAllByUserPet(userPetId)
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryRepository.kt
@@ -1,3 +1,5 @@
 package com.sseudam.pet
 
-interface PetPointHistoryRepository
+interface PetPointHistoryRepository {
+    fun findAllByUserPet(userPetId: Long): List<PetPointHistory.Info>
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetPointHistoryService.kt
@@ -1,0 +1,11 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Service
+
+@Service
+class PetPointHistoryService(
+    private val petPointHistoryAppender: PetPointHistoryAppender,
+    private val petPointHistoryReader: PetPointHistoryReader,
+) {
+    fun findAllByUserPet(userPetId: Long): List<PetPointHistory.Info> = petPointHistoryReader.readAllByUserPet(userPetId)
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetReader.kt
@@ -1,0 +1,14 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Component
+import java.time.Month
+
+@Component
+class PetReader(
+    private val petRepository: PetRepository,
+) {
+    fun readAllLatestSeasonPets(
+        currentYear: Int,
+        currentMonth: Month,
+    ): List<Pet.Info> = petRepository.findAllLatestSeasonPets(currentYear, currentMonth)
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetRepository.kt
@@ -1,3 +1,10 @@
 package com.sseudam.pet
 
-interface PetRepository
+import java.time.Month
+
+interface PetRepository {
+    fun findAllLatestSeasonPets(
+        currentYear: Int,
+        currentMonth: Month,
+    ): List<Pet.Info>
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetService.kt
@@ -1,0 +1,15 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Service
+import java.time.Month
+
+@Service
+class PetService(
+    private val petReader: PetReader,
+    private val petAppender: PetAppender,
+) {
+    fun findAllLatestSeasonPets(
+        currentYear: Int,
+        currentMonth: Month,
+    ): List<Pet.Info> = petReader.readAllLatestSeasonPets(currentYear, currentMonth)
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetAppender.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetAppender.kt
@@ -6,12 +6,15 @@ import org.springframework.stereotype.Component
 class UserPetAppender(
     private val userPetRepository: UserPetRepository,
 ) {
-    fun append(userId: Long): UserPet.Info =
+    fun append(
+        userId: Long,
+        pet: Pet.Info,
+    ): UserPet.Info =
         userPetRepository.save(
             UserPet.Create(
                 userId = userId,
-                petId = 1L,
-                nickname = Pet.LevelType.LEVEL_1.defaultName,
+                petId = pet.id,
+                nickname = "냥이",
                 point = 0L,
             ),
         )

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
@@ -1,5 +1,7 @@
 package com.sseudam.pet
 
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -11,34 +13,48 @@ class UserPetFacade(
     private val userPetPolicy: UserPetPolicy,
 ) {
     fun findPetInfo(userId: Long): UserPet.Info {
-        val currentYear = LocalDateTime.now().year
-        val currentMonth = LocalDateTime.now().month
-
+        val (currentYear, currentMonth) = LocalDateTime.now().let { it.year to it.month }
         val pets = petService.findAllLatestSeasonPets(currentYear, currentMonth)
-
-        val userPetInfo =
-            userPetService.findByUser(userId)
-                ?: userPetService.append(userId, pets.first())
-
-        return userPetInfo
+        return userPetService.findByUser(userId) ?: userPetService.append(userId, pets.first())
     }
 
     fun findCurrentSeasonPetHistory(userId: Long): List<UserPetLevelUpHistoryInfo> {
-        val currentYear = LocalDateTime.now().year
-        val currentMonth = LocalDateTime.now().month
-        val userPetInfo = userPetService.findByUser(userId)
+        val (currentYear, currentMonth) = LocalDateTime.now().let { it.year to it.month }
+        val userPetInfo = userPetService.findByUser(userId) ?: return emptyList()
+        return petLevelUpHistoryService
+            .findAllBy(currentYear, currentMonth, userPetInfo.id)
+            .map { history ->
+                UserPetLevelUpHistoryInfo(
+                    userId = userId,
+                    nickname = history.nickname,
+                    levelType = history.levelType,
+                    point = userPetPolicy.getMinLevelStandard(history.levelType),
+                    createdAt = history.createdAt,
+                )
+            }
+    }
 
-        val currentUserPetHistories =
-            petLevelUpHistoryService.findAllBy(currentYear, currentMonth, userPetInfo!!.id)
+    fun findAllPetHistory(userId: Long): List<UserPetLevelUpHistoryInfo> {
+        val (currentYear, currentMonth) = LocalDateTime.now().let { it.year to it.month }
+        val userPetHistories =
+            petLevelUpHistoryService
+                .findAllByUser(userId)
+                .filterNot { it.createdAt.year == currentYear && it.createdAt.month == currentMonth }
 
-        return currentUserPetHistories.map { history ->
-            UserPetLevelUpHistoryInfo(
-                userId = userId,
-                nickname = history.nickname,
-                levelType = history.levelType,
-                point = userPetPolicy.getMinLevelStandard(history.levelType),
-                createdAt = history.createdAt,
-            )
-        }
+        if (userPetHistories.isEmpty()) return emptyList()
+
+        return userPetHistories
+            .groupBy { it.userPetId }
+            .mapValues { (_, histories) -> histories.maxByOrNull { it.levelType.level } ?: throw ErrorException(ErrorType.NOT_FOUND_DATA) }
+            .values
+            .map { history ->
+                UserPetLevelUpHistoryInfo(
+                    userId = userId,
+                    nickname = history.nickname,
+                    levelType = history.levelType,
+                    point = userPetPolicy.getMinLevelStandard(history.levelType),
+                    createdAt = history.createdAt,
+                )
+            }
     }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
@@ -8,7 +8,7 @@ class UserPetFacade(
     private val userPetService: UserPetService,
     private val petService: PetService,
     private val petLevelUpHistoryService: PetLevelUpHistoryService,
-    private val petPointHistoryService: PetPointHistoryService,
+    private val userPetPolicy: UserPetPolicy,
 ) {
     fun findPetInfo(userId: Long): UserPet.Info {
         val currentYear = LocalDateTime.now().year
@@ -31,18 +31,12 @@ class UserPetFacade(
         val currentUserPetHistories =
             petLevelUpHistoryService.findAllBy(currentYear, currentMonth, userPetInfo!!.id)
 
-        val pointHistories = petPointHistoryService.findAllByUserPet(userPetInfo.id)
-
-        val pointHistoriesMap = pointHistories.associateBy { it.id }
         return currentUserPetHistories.map { history ->
             UserPetLevelUpHistoryInfo(
                 userId = userId,
                 nickname = history.nickname,
                 levelType = history.levelType,
-                point = (
-                    (pointHistoriesMap[history.pointHistoryId]?.previousPoint ?: 0L) +
-                        (pointHistoriesMap[history.pointHistoryId]?.additionalPoint ?: 0L)
-                ),
+                point = userPetPolicy.getMinLevelStandard(history.levelType),
                 createdAt = history.createdAt,
             )
         }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
@@ -1,0 +1,50 @@
+package com.sseudam.pet
+
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class UserPetFacade(
+    private val userPetService: UserPetService,
+    private val petService: PetService,
+    private val petLevelUpHistoryService: PetLevelUpHistoryService,
+    private val petPointHistoryService: PetPointHistoryService,
+) {
+    fun findPetInfo(userId: Long): UserPet.Info {
+        val currentYear = LocalDateTime.now().year
+        val currentMonth = LocalDateTime.now().month
+
+        val pets = petService.findAllLatestSeasonPets(currentYear, currentMonth)
+
+        val userPetInfo =
+            userPetService.findByUser(userId)
+                ?: userPetService.append(userId, pets.first())
+
+        return userPetInfo
+    }
+
+    fun findCurrentSeasonPetHistory(userId: Long): List<UserPetLevelUpHistoryInfo> {
+        val currentYear = LocalDateTime.now().year
+        val currentMonth = LocalDateTime.now().month
+        val userPetInfo = userPetService.findByUser(userId)
+
+        val currentUserPetHistories =
+            petLevelUpHistoryService.findAllBy(currentYear, currentMonth, userPetInfo!!.id)
+
+        val pointHistories = petPointHistoryService.findAllByUserPet(userPetInfo.id)
+
+        val pointHistoriesMap = pointHistories.associateBy { it.id }
+        return currentUserPetHistories.map { history ->
+            UserPetLevelUpHistoryInfo(
+                userId = userId,
+                nickname = history.nickname,
+                levelType = history.levelType,
+                point = (
+                    (pointHistoriesMap[history.pointHistoryId]?.previousPoint ?: 0L) +
+                        (pointHistoriesMap[history.pointHistoryId]?.additionalPoint ?: 0L)
+                ),
+                createdAt = history.createdAt,
+            )
+        }
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetLevelUpHistoryInfo.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetLevelUpHistoryInfo.kt
@@ -1,0 +1,11 @@
+package com.sseudam.pet
+
+import java.time.LocalDateTime
+
+data class UserPetLevelUpHistoryInfo(
+    val userId: Long,
+    val nickname: String,
+    val levelType: Pet.LevelType,
+    val point: Long,
+    val createdAt: LocalDateTime,
+)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetPolicy.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetPolicy.kt
@@ -12,7 +12,7 @@ class UserPetPolicy {
             cumulativePoint in LevelStandard.LEVEL_2_RANGE -> Pet.LevelType.LEVEL_2
             cumulativePoint in LevelStandard.LEVEL_3_RANGE -> Pet.LevelType.LEVEL_3
             cumulativePoint in LevelStandard.LEVEL_4_RANGE -> Pet.LevelType.LEVEL_4
-            LevelStandard.LEVEL_5_MIN <= cumulativePoint -> Pet.LevelType.LEVEL_5
+            LevelStandard.SPECIAL_MIN <= cumulativePoint -> Pet.LevelType.SPECIAL
             else -> throw ErrorException(ErrorType.INVALID_CUMULATIVE_POINT)
         }
 
@@ -22,6 +22,6 @@ class UserPetPolicy {
             Pet.LevelType.LEVEL_2 -> LevelStandard.LEVEL_2_MAX.toLong()
             Pet.LevelType.LEVEL_3 -> LevelStandard.LEVEL_3_MAX.toLong()
             Pet.LevelType.LEVEL_4 -> LevelStandard.LEVEL_4_MAX.toLong()
-            Pet.LevelType.LEVEL_5 -> Long.MAX_VALUE
+            Pet.LevelType.SPECIAL -> Long.MAX_VALUE
         }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetPolicy.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetPolicy.kt
@@ -24,4 +24,13 @@ class UserPetPolicy {
             Pet.LevelType.LEVEL_4 -> LevelStandard.LEVEL_4_MAX.toLong()
             Pet.LevelType.SPECIAL -> Long.MAX_VALUE
         }
+
+    fun getMinLevelStandard(levelType: Pet.LevelType): Long =
+        when (levelType) {
+            Pet.LevelType.LEVEL_1 -> LevelStandard.LEVEL_1_MIN.toLong()
+            Pet.LevelType.LEVEL_2 -> LevelStandard.LEVEL_2_MIN.toLong()
+            Pet.LevelType.LEVEL_3 -> LevelStandard.LEVEL_3_MIN.toLong()
+            Pet.LevelType.LEVEL_4 -> LevelStandard.LEVEL_4_MIN.toLong()
+            Pet.LevelType.SPECIAL -> LevelStandard.SPECIAL_MIN.toLong()
+        }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetReader.kt
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Component
 class UserPetReader(
     private val userPetRepository: UserPetRepository,
 ) {
-    fun findPetInfo(userId: Long): UserPet.Info? = userPetRepository.findByUserId(userId)
+    fun readPetInfoByUser(userId: Long): UserPet.Info? = userPetRepository.findByUserId(userId)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetService.kt
@@ -8,7 +8,12 @@ class UserPetService(
     private val userPetReader: UserPetReader,
     private val userPetUpdater: UserPetUpdater,
 ) {
-    fun findPetInfo(userId: Long): UserPet.Info = userPetReader.findPetInfo(userId) ?: userPetAppender.append(userId)
+    fun findByUser(userId: Long): UserPet.Info? = userPetReader.readPetInfoByUser(userId)
+
+    fun append(
+        userId: Long,
+        pet: Pet.Info,
+    ): UserPet.Info = userPetAppender.append(userId, pet)
 
     fun updatePetName(
         userId: Long,

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetCoreRepository.kt
@@ -2,18 +2,22 @@ package com.sseudam.storage.db.core.pet
 
 import com.sseudam.pet.Pet
 import com.sseudam.pet.PetRepository
+import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Repository
 import java.time.Month
 
 @Repository
 class PetCoreRepository(
     private val petJpaRepository: PetJpaRepository,
+    private val txAdvice: TxAdvice,
 ) : PetRepository {
     override fun findAllLatestSeasonPets(
         currentYear: Int,
         currentMonth: Month,
     ): List<Pet.Info> =
-        petJpaRepository
-            .findAllByYearAndMonthly(currentYear, currentMonth)
-            .map { it.toPetInfo() }
+        txAdvice.readOnly {
+            petJpaRepository
+                .findAllByYearAndMonthly(currentYear, currentMonth)
+                .map { it.toPetInfo() }
+        }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetCoreRepository.kt
@@ -1,9 +1,19 @@
 package com.sseudam.storage.db.core.pet
 
+import com.sseudam.pet.Pet
 import com.sseudam.pet.PetRepository
 import org.springframework.stereotype.Repository
+import java.time.Month
 
 @Repository
 class PetCoreRepository(
     private val petJpaRepository: PetJpaRepository,
-) : PetRepository
+) : PetRepository {
+    override fun findAllLatestSeasonPets(
+        currentYear: Int,
+        currentMonth: Month,
+    ): List<Pet.Info> =
+        petJpaRepository
+            .findAllByYearAndMonthly(currentYear, currentMonth)
+            .map { it.toPetInfo() }
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetEntity.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import java.time.Month
+import java.time.Year
 
 @Entity
 @Table(name = "t_pet")
@@ -16,6 +17,7 @@ class PetEntity(
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(15)")
     val levelType: Pet.LevelType,
+    val year: Int,
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(10)")
     val monthly: Month,
@@ -23,6 +25,7 @@ class PetEntity(
     constructor(petCreate: Pet.Create) : this(
         name = petCreate.name,
         levelType = petCreate.levelType,
+        year = Year.now().value,
         monthly = petCreate.monthly,
     )
 
@@ -31,6 +34,7 @@ class PetEntity(
             id = id!!,
             name = name,
             levelType = levelType,
+            year = year,
             monthly = monthly,
             createdAt = createdAt,
         )

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpCoreRepository.kt
@@ -1,9 +1,0 @@
-package com.sseudam.storage.db.core.pet
-
-import com.sseudam.pet.PetLevelUpRepository
-import org.springframework.stereotype.Repository
-
-@Repository
-class PetLevelUpCoreRepository(
-    private val petLevelUpJpaRepository: PetLevelUpJpaRepository,
-) : PetLevelUpRepository

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryCoreHistoryRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryCoreHistoryRepository.kt
@@ -2,19 +2,37 @@ package com.sseudam.storage.db.core.pet
 
 import com.sseudam.pet.PetLevelUpHistory
 import com.sseudam.pet.PetLevelUpHistoryRepository
+import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Repository
 import java.time.Month
 
 @Repository
 class PetLevelUpHistoryCoreHistoryRepository(
     private val petLevelUpHistoryJpaRepository: PetLevelUpHistoryJpaRepository,
+    private val txAdvice: TxAdvice,
 ) : PetLevelUpHistoryRepository {
     override fun findAllBy(
         currentYear: Int,
         currentMonth: Month,
         userPetId: Long,
     ): List<PetLevelUpHistory.Info> =
-        petLevelUpHistoryJpaRepository
-            .findAllByYearAndMonthlyAndUserPetId(currentYear, currentMonth, userPetId)
-            .map { it.toPetLevelUpHistoryInfo() }
+        txAdvice.readOnly {
+            petLevelUpHistoryJpaRepository
+                .findAllByYearAndMonthlyAndUserPetId(currentYear, currentMonth, userPetId)
+                .map { it.toPetLevelUpHistoryInfo() }
+        }
+
+    override fun findAllBy(userPetId: Long): List<PetLevelUpHistory.Info> =
+        txAdvice.readOnly {
+            petLevelUpHistoryJpaRepository
+                .findAllByUserPetId(userPetId)
+                .map { it.toPetLevelUpHistoryInfo() }
+        }
+
+    override fun findAllByUserId(userId: Long): List<PetLevelUpHistory.Info> =
+        txAdvice.readOnly {
+            petLevelUpHistoryJpaRepository
+                .findAllByUserId(userId)
+                .map { it.toPetLevelUpHistoryInfo() }
+        }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryCoreHistoryRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryCoreHistoryRepository.kt
@@ -1,0 +1,20 @@
+package com.sseudam.storage.db.core.pet
+
+import com.sseudam.pet.PetLevelUpHistory
+import com.sseudam.pet.PetLevelUpHistoryRepository
+import org.springframework.stereotype.Repository
+import java.time.Month
+
+@Repository
+class PetLevelUpHistoryCoreHistoryRepository(
+    private val petLevelUpHistoryJpaRepository: PetLevelUpHistoryJpaRepository,
+) : PetLevelUpHistoryRepository {
+    override fun findAllBy(
+        currentYear: Int,
+        currentMonth: Month,
+        userPetId: Long,
+    ): List<PetLevelUpHistory.Info> =
+        petLevelUpHistoryJpaRepository
+            .findAllByYearAndMonthlyAndUserPetId(currentYear, currentMonth, userPetId)
+            .map { it.toPetLevelUpHistoryInfo() }
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryEntity.kt
@@ -8,17 +8,28 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
+import java.time.Month
 
 @Entity
 @Table(name = "t_pet_level_up_history")
 class PetLevelUpHistoryEntity(
     val userPetId: Long,
+    val pointHistoryId: Long,
+    val nickname: String,
+    val year: Int,
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(10)")
+    val monthly: Month,
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(15)")
     val levelType: Pet.LevelType,
 ) : BaseEntity() {
     constructor(create: PetLevelUpHistory.Create) : this(
         userPetId = create.userPetId,
+        pointHistoryId = create.pointHistoryId,
+        nickname = create.nickname,
+        year = create.year,
+        monthly = create.monthly,
         levelType = create.levelType,
     )
 
@@ -26,6 +37,10 @@ class PetLevelUpHistoryEntity(
         PetLevelUpHistory.Info(
             id = id!!,
             userPetId = userPetId,
+            pointHistoryId = pointHistoryId,
+            nickname = nickname,
+            year = year,
+            monthly = monthly,
             levelType = levelType,
             createdAt = createdAt,
             updatedAt = updatedAt,

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryEntity.kt
@@ -13,6 +13,7 @@ import java.time.Month
 @Entity
 @Table(name = "t_pet_level_up_history")
 class PetLevelUpHistoryEntity(
+    val userId: Long,
     val userPetId: Long,
     val pointHistoryId: Long,
     val nickname: String,
@@ -25,6 +26,7 @@ class PetLevelUpHistoryEntity(
     val levelType: Pet.LevelType,
 ) : BaseEntity() {
     constructor(create: PetLevelUpHistory.Create) : this(
+        userId = create.userId,
         userPetId = create.userPetId,
         pointHistoryId = create.pointHistoryId,
         nickname = create.nickname,
@@ -36,6 +38,7 @@ class PetLevelUpHistoryEntity(
     fun toPetLevelUpHistoryInfo() =
         PetLevelUpHistory.Info(
             id = id!!,
+            userId = userId,
             userPetId = userPetId,
             pointHistoryId = pointHistoryId,
             nickname = nickname,

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryJpaRepository.kt
@@ -4,11 +4,12 @@ import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpql
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.Month
 
-interface PetJpaRepository :
-    JpaRepository<PetEntity, Long>,
+interface PetLevelUpHistoryJpaRepository :
+    JpaRepository<PetLevelUpHistoryEntity, Long>,
     KotlinJdslJpqlExecutor {
-    fun findAllByYearAndMonthly(
+    fun findAllByYearAndMonthlyAndUserPetId(
         year: Int,
         monthly: Month,
-    ): MutableList<PetEntity>
+        userPetId: Long,
+    ): List<PetLevelUpHistoryEntity>
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpHistoryJpaRepository.kt
@@ -12,4 +12,8 @@ interface PetLevelUpHistoryJpaRepository :
         monthly: Month,
         userPetId: Long,
     ): List<PetLevelUpHistoryEntity>
+
+    fun findAllByUserPetId(userPetId: Long): List<PetLevelUpHistoryEntity>
+
+    fun findAllByUserId(userId: Long): MutableList<PetLevelUpHistoryEntity>
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetLevelUpJpaRepository.kt
@@ -1,8 +1,0 @@
-package com.sseudam.storage.db.core.pet
-
-import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
-import org.springframework.data.jpa.repository.JpaRepository
-
-interface PetLevelUpJpaRepository :
-    JpaRepository<PetLevelUpHistoryEntity, Long>,
-    KotlinJdslJpqlExecutor

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryCoreRepository.kt
@@ -1,9 +1,15 @@
 package com.sseudam.storage.db.core.pet
 
+import com.sseudam.pet.PetPointHistory
 import com.sseudam.pet.PetPointHistoryRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 class PetPointHistoryCoreRepository(
     private val petPointHistoryJpaRepository: PetPointHistoryJpaRepository,
-) : PetPointHistoryRepository
+) : PetPointHistoryRepository {
+    override fun findAllByUserPet(userPetId: Long): List<PetPointHistory.Info> =
+        petPointHistoryJpaRepository
+            .findAllByUserPetId(userPetId)
+            .map { it.toPetPointHistoryInfo() }
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryCoreRepository.kt
@@ -2,14 +2,18 @@ package com.sseudam.storage.db.core.pet
 
 import com.sseudam.pet.PetPointHistory
 import com.sseudam.pet.PetPointHistoryRepository
+import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Repository
 
 @Repository
 class PetPointHistoryCoreRepository(
     private val petPointHistoryJpaRepository: PetPointHistoryJpaRepository,
+    private val txAdvice: TxAdvice,
 ) : PetPointHistoryRepository {
     override fun findAllByUserPet(userPetId: Long): List<PetPointHistory.Info> =
-        petPointHistoryJpaRepository
-            .findAllByUserPetId(userPetId)
-            .map { it.toPetPointHistoryInfo() }
+        txAdvice.readOnly {
+            petPointHistoryJpaRepository
+                .findAllByUserPetId(userPetId)
+                .map { it.toPetPointHistoryInfo() }
+        }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryEntity.kt
@@ -11,27 +11,27 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "t_pet_point_history")
 class PetPointHistoryEntity(
-    val userId: Long,
-    val petId: Long,
+    val userPetId: Long,
+    val previousPoint: Long,
+    val additionalPoint: Long,
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")
     val event: PetPointHistory.PointEvent,
-    val point: Long,
 ) : BaseEntity() {
     constructor(create: PetPointHistory.Create) : this(
-        userId = create.userId,
-        petId = create.petId,
+        userPetId = create.userPetId,
+        previousPoint = create.previousPoint,
+        additionalPoint = create.additionalPoint,
         event = create.event,
-        point = create.point,
     )
 
     fun toPetPointHistoryInfo() =
         PetPointHistory.Info(
             id = id!!,
-            userId = userId,
-            petId = petId,
+            userPetId = userPetId,
             event = event,
-            point = point,
+            previousPoint = previousPoint,
+            additionalPoint = additionalPoint,
             createdAt = createdAt,
         )
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetPointHistoryJpaRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface PetPointHistoryJpaRepository :
     JpaRepository<PetPointHistoryEntity, Long>,
-    KotlinJdslJpqlExecutor
+    KotlinJdslJpqlExecutor {
+    fun findAllByUserPetId(userPetId: Long): MutableList<PetPointHistoryEntity>
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
@@ -4,29 +4,37 @@ import com.sseudam.pet.UserPet
 import com.sseudam.pet.UserPetRepository
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
+import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Repository
 
 @Repository
 class UserPetCoreRepository(
     private val userPetJpaRepository: UserPetJpaRepository,
+    private val txAdvice: TxAdvice,
 ) : UserPetRepository {
     override fun save(createUserPet: UserPet.Create): UserPet.Info =
-        userPetJpaRepository
-            .save(
-                UserPetEntity(
-                    createUserPet,
-                ),
-            ).toUserPetInfo()
+        txAdvice.write {
+            userPetJpaRepository
+                .save(
+                    UserPetEntity(
+                        createUserPet,
+                    ),
+                ).toUserPetInfo()
+        }
 
-    override fun findByUserId(userId: Long): UserPet.Info? = userPetJpaRepository.findByUserIdAndDeletedAtIsNull(userId)?.toUserPetInfo()
+    override fun findByUserId(userId: Long): UserPet.Info? =
+        txAdvice.readOnly {
+            userPetJpaRepository.findByUserIdAndDeletedAtIsNull(userId)?.toUserPetInfo()
+        }
 
     override fun updateNickname(
         userId: Long,
         nickname: String,
-    ): UserPet.Info {
-        val userPet =
-            userPetJpaRepository
-                .findByUserIdAndDeletedAtIsNull(userId) ?: throw ErrorException(ErrorType.NOT_FOUND_DATA)
-        return userPet.updateNickname(nickname).toUserPetInfo()
-    }
+    ): UserPet.Info =
+        txAdvice.write {
+            val userPet =
+                userPetJpaRepository
+                    .findByUserIdAndDeletedAtIsNull(userId) ?: throw ErrorException(ErrorType.NOT_FOUND_DATA)
+            userPet.updateNickname(nickname).toUserPetInfo()
+        }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #83 

## 📌 작업 내용 및 특이 사항

- c4590facdc455c89805d7bb911c4f72285ec5665: 시즌 별 성장 기록 조회 API
- 94aeb6526531084334325c7335023d924eafcf22: 레벨 기준에 따른 포인트 기준
- 3813210431b6e7d07019a5f9393e6a5ef4b09c6b: 사용자 펫 전체 성장 기록 조회

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added endpoints to view current season and full pet growth history.
  - Introduced new response formats for pet level history data.
  - Added support for managing and retrieving pet point history.

- **Improvements**
  - Enhanced pet info responses with more descriptive nicknames.
  - Adjusted pet level boundaries and improved level naming for clarity.
  - Expanded pet and history data to include year and month details.

- **Bug Fixes**
  - Improved transaction handling for pet-related data operations.

- **Refactor**
  - Streamlined internal logic for managing pet and point history data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->