### PR TITLE
[Feature] Admin Reissue

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -3,6 +3,7 @@ package com.sseudam.admin.application
 import com.sseudam.admin.domain.AdminToken
 import com.sseudam.admin.domain.AdminUserProfile
 import com.sseudam.auth.AuthenticationService
+import com.sseudam.auth.token.RefreshToken
 import com.sseudam.report.ReportService
 import com.sseudam.report.ReportType
 import com.sseudam.report.SpotReport
@@ -42,6 +43,11 @@ class AdminFacade(
         }
 
         val token = authService.adminLogin(admin.id)
+        return AdminToken(token.accessToken, token.refreshToken)
+    }
+
+    fun reissue(refreshToken: RefreshToken): AdminToken {
+        val token = authService.adminReissue(refreshToken)
         return AdminToken(token.accessToken, token.refreshToken)
     }
 

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminRefreshToken.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/domain/AdminRefreshToken.kt
@@ -1,0 +1,15 @@
+package com.sseudam.admin.domain
+
+import com.sseudam.auth.token.RefreshToken
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "어드민 리프레시 토큰 요청 Json")
+data class AdminRefreshToken(
+    @Schema(description = "리프레시 토큰", example = "refresh_token")
+    val refreshToken: String,
+) {
+    fun toRefreshToken(): RefreshToken =
+        RefreshToken(
+            token = refreshToken,
+        )
+}

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/AdminController.kt
@@ -1,6 +1,7 @@
 package com.sseudam.admin.presentation
 
 import com.sseudam.admin.application.AdminFacade
+import com.sseudam.admin.domain.AdminRefreshToken
 import com.sseudam.admin.presentation.request.AdminLoginRequest
 import com.sseudam.admin.presentation.request.report.UpdateReportRequest
 import com.sseudam.admin.presentation.response.AdminTokenResponse
@@ -37,6 +38,15 @@ class AdminController(
         @RequestBody request: AdminLoginRequest,
     ): AdminTokenResponse {
         val token = adminFacade.login(request.loginId, request.password)
+        return AdminTokenResponse.of(token)
+    }
+
+    @Operation(summary = "어드민 토큰 재발급", description = "어드민 토큰을 재발급합니다.")
+    @PostMapping("/reissue")
+    fun reissueToken(
+        @RequestBody request: AdminRefreshToken,
+    ): AdminTokenResponse {
+        val token = adminFacade.reissue(request.toRefreshToken())
         return AdminTokenResponse.of(token)
     }
 

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/config/SecurityConfig.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/config/SecurityConfig.kt
@@ -135,6 +135,7 @@ class SecurityConfig(
                     "/api/v1/auth",
                     "/api/v1/trash-spots/**",
                     "/api/v1/admin/login",
+                    "/api/v1/admin/reissue",
                 ).permitAll()
 
             authorize

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationProcessor.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationProcessor.kt
@@ -70,4 +70,6 @@ class AuthenticationProcessor(
         adminId: Long,
         grantedAuthorities: List<GrantedAuthority>,
     ): Token = tokenRepository.create(adminId, grantedAuthorities)
+
+    fun adminRenew(refreshToken: String): Token = tokenRepository.adminRefresh(refreshToken)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationService.kt
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Service
 class AuthenticationService(
     private val authenticationProcessor: AuthenticationProcessor,
 ) {
-    fun adminLogin(adminId: Long): Token = authenticationProcessor.adminLogin(adminId, listOf(GrantedAuthority(AuthorityType.ADMIN)))
-
     fun login(
         deviceId: String?,
         user: User,
@@ -39,4 +37,8 @@ class AuthenticationService(
     fun withdrawUser(userKey: String) {
         authenticationProcessor.withdrawal(userKey)
     }
+
+    fun adminLogin(adminId: Long): Token = authenticationProcessor.adminLogin(adminId, listOf(GrantedAuthority(AuthorityType.ADMIN)))
+
+    fun adminReissue(refreshToken: RefreshToken): Token = authenticationProcessor.adminRenew(refreshToken.token)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/token/repository/TokenRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/token/repository/TokenRepository.kt
@@ -24,6 +24,8 @@ interface TokenRepository {
 
     fun renew(refreshToken: String): Token
 
+    fun adminRefresh(refreshToken: String): Token
+
     fun remove(token: String): String
 
     fun removeByUserKey(userKey: String)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #92 

## 📌 작업 내용 및 특이 사항

- 862412441f83d94f1c3d341c5acffd109556611e: 어드민 토큰 재갱신 API

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new POST endpoint for admin token reissuance, allowing admins to obtain a new token using a refresh token.
  - Introduced support for admin token refresh requests without requiring authentication on the reissue endpoint.

- **Documentation**
  - Enhanced API documentation for the new admin token reissue request payload and endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->