### PR TITLE
[Fix] Pet season init

### DIFF
--- a/sseudam-batch/src/main/kotlin/com/sseudam/pet/PetScheduler.kt
+++ b/sseudam-batch/src/main/kotlin/com/sseudam/pet/PetScheduler.kt
@@ -20,6 +20,7 @@ class PetScheduler(
     private val userDeviceService: UserDeviceService,
     private val fcmSender: FcmSender,
     private val userService: UserService,
+    private val userPetService: UserPetService,
     private val notificationService: NotificationService,
     private val notificationStoredKeyGenerator: NotificationStoredKeyGenerator,
 ) {
@@ -28,7 +29,8 @@ class PetScheduler(
         val nextDay = LocalDate.now().plusDays(1)
         val currentYear = nextDay.year
         val currentMonth = Month.from(nextDay)
-        petService.createPetSeason(currentYear, currentMonth)
+        val createLevelOnePet = petService.createPetSeason(currentYear, currentMonth)
+        userPetService.initPointForAllUsers(createLevelOnePet.id)
         sendNewPetNotifications()
     }
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetAppender.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetAppender.kt
@@ -6,7 +6,5 @@ import org.springframework.stereotype.Component
 class PetAppender(
     private val petRepository: PetRepository,
 ) {
-    fun appendSeasonPet(create: Pet.Create) {
-        petRepository.save(create)
-    }
+    fun appendSeasonPet(create: Pet.Create): Pet.Info = petRepository.save(create)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetRepository.kt
@@ -3,7 +3,7 @@ package com.sseudam.pet
 import java.time.Month
 
 interface PetRepository {
-    fun save(create: Pet.Create)
+    fun save(create: Pet.Create): Pet.Info
 
     fun findBy(petId: Long): Pet.Info
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/PetService.kt
@@ -1,5 +1,7 @@
 package com.sseudam.pet
 
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
 import org.springframework.stereotype.Service
 import java.time.Month
 
@@ -11,17 +13,19 @@ class PetService(
     fun createPetSeason(
         currentYear: Int,
         currentMonth: Month,
-    ) {
-        Pet.LevelType.entries.forEach {
-            petAppender.appendSeasonPet(
-                Pet.Create(
-                    name = "냥이",
-                    levelType = it,
-                    year = currentYear,
-                    monthly = currentMonth,
-                ),
-            )
-        }
+    ): Pet.Info {
+        val petInfos =
+            Pet.LevelType.entries.map {
+                petAppender.appendSeasonPet(
+                    Pet.Create(
+                        name = "냥이",
+                        levelType = it,
+                        year = currentYear,
+                        monthly = currentMonth,
+                    ),
+                )
+            }
+        return petInfos.firstOrNull() ?: throw ErrorException(ErrorType.FAILED_PET_CREATION)
     }
 
     fun findBy(petId: Long): Pet.Info = petReader.readBy(petId)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetRepository.kt
@@ -24,4 +24,6 @@ interface UserPetRepository {
         userPetId: Long,
         point: Long,
     ): UserPet.Info
+
+    fun initPoint(petId: Long)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetService.kt
@@ -33,4 +33,8 @@ class UserPetService(
         userPetId: Long,
         petId: Long,
     ): UserPet.Info = userPetUpdater.updatePetId(userPetId, petId)
+
+    fun initPointForAllUsers(petId: Long) {
+        userPetUpdater.initPoint(petId)
+    }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetUpdater.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetUpdater.kt
@@ -24,4 +24,8 @@ class UserPetUpdater(
             userPetId = userPetId,
             action = action,
         )
+
+    fun initPoint(petId: Long) {
+        userPetRepository.initPoint(petId)
+    }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
@@ -118,4 +118,12 @@ enum class ErrorType(
         "오늘 쓰레기통 방문 횟수를 초과했습니다.",
         ErrorLevel.WARN,
     ),
+
+    /** Pet */
+    FAILED_PET_CREATION(
+        500,
+        ErrorKind.INTERNAL_SERVER_ERROR,
+        "펫 생성에 실패했습니다.",
+        ErrorLevel.ERROR,
+    ),
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/PetCoreRepository.kt
@@ -12,11 +12,10 @@ class PetCoreRepository(
     private val petJpaRepository: PetJpaRepository,
     private val txAdvice: TxAdvice,
 ) : PetRepository {
-    override fun save(create: Pet.Create) {
+    override fun save(create: Pet.Create): Pet.Info =
         txAdvice.write {
-            petJpaRepository.save(PetEntity(create))
+            petJpaRepository.save(PetEntity(create)).toPetInfo()
         }
-    }
 
     override fun findBy(petId: Long): Pet.Info =
         txAdvice.readOnly {

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class UserPetCoreRepository(
+    private val userPetCustomRepository: UserPetCustomRepository,
     private val userPetJpaRepository: UserPetJpaRepository,
     private val txAdvice: TxAdvice,
 ) : UserPetRepository {
@@ -72,4 +73,8 @@ class UserPetCoreRepository(
                     .findByIdOrElseThrow(userPetId)
             userPet.updatePoint(point).toUserPetInfo()
         }
+
+    override fun initPoint(petId: Long) {
+        userPetCustomRepository.resetSeasonUserPetPoint(petId)
+    }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCustomRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCustomRepository.kt
@@ -1,0 +1,29 @@
+package com.sseudam.storage.db.core.pet
+
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.querymodel.Queryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.update.UpdateQuery
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.extension.createQuery
+import com.sseudam.storage.db.core.support.JDSLExtensions
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserPetCustomRepository(
+    private val entityManager: EntityManager,
+    private val jdslRenderContext: RenderContext,
+) {
+    fun <T : Any> updateAll(update: Jpql.() -> Queryable<UpdateQuery<T>>): Int {
+        val query = jpql(JDSLExtensions) { update().toQuery() }
+        return entityManager.createQuery(query, jdslRenderContext).executeUpdate()
+    }
+
+    fun resetSeasonUserPetPoint(petId: Long): Int =
+        updateAll {
+            update(entity(UserPetEntity::class))
+                .set(path(UserPetEntity::point), 0)
+                .set(path(UserPetEntity::petId), petId)
+        }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #129 

## 📌 작업 내용 및 특이 사항

- df7b1837785f13c31e814291ed24edda3382fdb3: 펫 시즌 초기화 시 포인트 초기화

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initialization of user points for all users when a new pet season is created.
  * Introduced new error message for pet creation failures.

* **Enhancements**
  * Improved pet season creation to provide more detailed feedback and error handling.
  * Added ability to reset user pet points for a specific pet season.

* **Bug Fixes**
  * Ensured that pet creation either returns valid information or fails explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->