### PR TITLE
[Fix] Create report image path

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
@@ -31,7 +31,7 @@ class ReportController(
         @RequestBody request: SpotReportCreateRequest,
     ): ReportImageUrlResponse {
         val report =
-            reportService.createSpotReport(
+            reportFacade.createSpotReport(
                 report =
                     SpotReport.Create(
                         userId = user.id,
@@ -48,7 +48,7 @@ class ReportController(
             )
         return ReportImageUrlResponse.of(
             report = report.first,
-            s3ImageUrl = report.second,
+            presignedUrl = report.second,
         )
     }
 

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/response/ReportImageUrlResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/response/ReportImageUrlResponse.kt
@@ -1,6 +1,5 @@
 package com.sseudam.presentation.v1.report.response
 
-import com.sseudam.common.S3ImageUrl
 import com.sseudam.report.SpotReport
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -14,7 +13,7 @@ data class ReportImageUrlResponse(
     companion object {
         fun of(
             report: SpotReport.Info,
-            s3ImageUrl: S3ImageUrl,
-        ) = ReportImageUrlResponse(report.id, s3ImageUrl.presignedUrl)
+            presignedUrl: String,
+        ) = ReportImageUrlResponse(report.id, presignedUrl)
     }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportFacade.kt
@@ -4,6 +4,8 @@ import com.sseudam.common.ImageS3Caller
 import com.sseudam.common.S3ImageUrl
 import com.sseudam.pet.PetPointAction
 import com.sseudam.pet.event.PetEventPublisher
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
 import com.sseudam.trashspot.TrashSpotService
 import com.sseudam.trashspot.image.TrashSpotImageService
 import org.springframework.stereotype.Service
@@ -30,7 +32,13 @@ class ReportFacade(
 
     fun createSpotReport(report: SpotReport.Create): Pair<SpotReport.Info, String> {
         val presignedUrl: String?
-        var imageUrl = trashSpotImageService.findBySpotId(report.spotId).maxBy { it.updatedAt!! }.imageUrl
+        val images = trashSpotImageService.findBySpotId(report.spotId)
+        var imageUrl =
+            images
+                .filter { it.updatedAt != null }
+                .maxByOrNull { it.updatedAt!! }
+                ?.imageUrl
+                ?: throw ErrorException(ErrorType.NOT_FOUND_DATA)
         if (report.reportType == ReportType.PHOTO) {
             val s3ImageUrl: S3ImageUrl = imageS3Caller.createUploadUrl(report.userId, LocalDateTime.now(), REPORT_IMAGE_PATH)
             presignedUrl = s3ImageUrl.presignedUrl

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportFacade.kt
@@ -1,17 +1,47 @@
 package com.sseudam.report
 
+import com.sseudam.common.ImageS3Caller
+import com.sseudam.common.S3ImageUrl
+import com.sseudam.pet.PetPointAction
+import com.sseudam.pet.event.PetEventPublisher
 import com.sseudam.trashspot.TrashSpotService
+import com.sseudam.trashspot.image.TrashSpotImageService
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Service
 class ReportFacade(
     private val reportService: ReportService,
     private val trashSpotService: TrashSpotService,
+    private val trashSpotImageService: TrashSpotImageService,
+    private val imageS3Caller: ImageS3Caller,
+    private val petEventPublisher: PetEventPublisher,
 ) {
+    companion object {
+        private const val REPORT_IMAGE_PATH = "report"
+    }
+
     fun validateSpotReport(name: String): Boolean {
         reportService.validateSpotReportName(name)
         trashSpotService.validateSpotName(name)
 
         return true
+    }
+
+    fun createSpotReport(report: SpotReport.Create): Pair<SpotReport.Info, String> {
+        val presignedUrl: String?
+        var imageUrl = trashSpotImageService.findBySpotId(report.spotId).maxBy { it.updatedAt!! }.imageUrl
+        if (report.reportType == ReportType.PHOTO) {
+            val s3ImageUrl: S3ImageUrl = imageS3Caller.createUploadUrl(report.userId, LocalDateTime.now(), REPORT_IMAGE_PATH)
+            presignedUrl = s3ImageUrl.presignedUrl
+            imageUrl = s3ImageUrl.imageUrl
+        } else {
+            presignedUrl = null
+        }
+
+        val spotReport = reportService.appendReport(imageUrl, report)
+        petEventPublisher.publish(report.userId, PetPointAction.REPORT)
+
+        return spotReport to (presignedUrl ?: imageUrl)
     }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportService.kt
@@ -1,7 +1,5 @@
 package com.sseudam.report
 
-import com.sseudam.common.ImageS3Caller
-import com.sseudam.common.S3ImageUrl
 import com.sseudam.pet.PetPointAction
 import com.sseudam.pet.event.PetEventPublisher
 import com.sseudam.report.event.ReportEventPublisher
@@ -11,7 +9,6 @@ import com.sseudam.support.error.ErrorType
 import com.sseudam.support.page.Page
 import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
 
 @Service
 class ReportService(
@@ -21,19 +18,11 @@ class ReportService(
     private val txAdvice: TxAdvice,
     private val reportEventPublisher: ReportEventPublisher,
     private val petEventPublisher: PetEventPublisher,
-    private val imageS3Caller: ImageS3Caller,
 ) {
-    companion object {
-        private const val REPORT_IMAGE_PATH = "report"
-    }
-
-    fun createSpotReport(report: SpotReport.Create): Pair<SpotReport.Info, S3ImageUrl> {
-        val uploadUrl = imageS3Caller.createUploadUrl(report.userId, LocalDateTime.now(), REPORT_IMAGE_PATH)
-        val spotReport = reportAppender.append(uploadUrl.imageUrl, report)
-
-        petEventPublisher.publish(report.userId, PetPointAction.REPORT)
-        return spotReport to uploadUrl
-    }
+    fun appendReport(
+        imageUrl: String,
+        report: SpotReport.Create,
+    ): SpotReport.Info = reportAppender.append(imageUrl, report)
 
     fun findAllReportByUserId(userId: Long): List<SpotReport.Info> = reportReader.readAllByUserId(userId)
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImage.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/image/TrashSpotImage.kt
@@ -1,5 +1,7 @@
 package com.sseudam.trashspot.image
 
+import java.time.LocalDateTime
+
 class TrashSpotImage {
     /** TrashSpotImage Create
      * @property trashSpotId 쓰레기통 id
@@ -19,5 +21,6 @@ class TrashSpotImage {
         val id: Long,
         val trashSpotId: Long,
         val imageUrl: String,
+        val updatedAt: LocalDateTime?,
     )
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/image/TrashSpotImageEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/image/TrashSpotImageEntity.kt
@@ -21,6 +21,7 @@ class TrashSpotImageEntity(
             id = id!!,
             trashSpotId = trashSpotId,
             imageUrl = imageUrl,
+            updatedAt = updatedAt,
         )
 
     fun updateImageUrl(imageUrl: String) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #133 

## 📌 작업 내용 및 특이 사항

- ac9f5fc0b762f70fdb98adbdd17d5d2a47557862: 신고 시 이미지 신고가 아닌 경우 presignedUrl 미생성

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying the last updated time for trash spot images.
  * Enhanced spot report creation with improved image URL handling and event publishing.

* **Bug Fixes**
  * Improved handling of image upload URLs when creating spot reports.

* **Refactor**
  * Streamlined the process for creating spot reports and generating presigned image upload URLs.
  * Updated naming conventions for image URL parameters in report responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->