### PR TITLE
[Fix] Monitoring tracing dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,13 +53,14 @@ line_kotlin_jdsl = "3.4.1"
 spring_mockk = "4.0.2"
 
 # firebase
-firebase = "9.4.0"
+firebase = "9.5.0"
 
 # OpenFeign
 spring_cloud_openfeign = "4.2.0"
 openfeign_hc5 = "13.1"
 openfeign_micrometer = "13.1"
 
+micrometer = "1.5.0"
 [plugins]
 # Kotlin Plugins
 kotlin_jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -197,7 +198,8 @@ epages_restdocs_api_spec_mock_mvc = { module = "com.epages:restdocs-api-spec-moc
 epages_restdocs_api_spec_restassured = { module = "com.epages:restdocs-api-spec-restassured", version.ref = "epages_restdocs_api_spec" }
 
 # Monitoring & Logging Libraries
-micrometer_tracing_bridge_brave = { module = "io.micrometer:micrometer-tracing-bridge-brave" }
+micrometer_tracing_bridge_brave = { module = "io.micrometer:micrometer-tracing-bridge-brave", version.ref = "micrometer" }
+micrometer_tracing = { module = "io.micrometer:micrometer-tracing", version.ref = "micrometer" }
 micrometer_registry_prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
 slf4j = { module = "org.slf4j:slf4j-api", version = "2.0.9" }
 

--- a/sseudam-supports/logging/build.gradle.kts
+++ b/sseudam-supports/logging/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
     implementation(libs.micrometer.tracing.bridge.brave)
+    implementation(libs.micrometer.tracing)
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #135 

## 📌 작업 내용 및 특이 사항

- 5021967c3e5063df31b3fc6919950847b026210a: 모니터링 tracing 의존성 추가

## 📝 참고

- firebase 의존성 9.5.0 up

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the core Micrometer Tracing library.

* **Chores**
  * Updated Firebase dependency to version 9.5.0.
  * Updated Micrometer-related libraries to use version 1.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->