### PR TITLE
[Fix] Suggestion dup address

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/advice/ApiExceptionAdvice.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/advice/ApiExceptionAdvice.kt
@@ -1,5 +1,7 @@
 package com.sseudam.presentation.advice
 
+import com.sseudam.support.error.AuthenticationErrorException
+import com.sseudam.support.error.AuthenticationErrorType
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorResponse
 import com.sseudam.support.error.ErrorType
@@ -94,6 +96,15 @@ class ApiExceptionAdvice : ResponseEntityExceptionHandler() {
         val errorResponse = ErrorResponse.of(errorCode.name, errorCode.message)
         val apiResponse = ApiResponse.fail(errorCode.status, errorResponse)
         return ResponseEntity.status(errorCode.status).body(apiResponse)
+    }
+
+    @ExceptionHandler(AuthenticationErrorException::class)
+    fun handleAuthenticationCustomException(e: AuthenticationErrorException): ResponseEntity<ApiResponse<ErrorResponse>> {
+        log.error("sseudam CustomException : {}", e.message, e)
+        val errorCode: AuthenticationErrorType = e.authenticationErrorType
+        val errorResponse = ErrorResponse.of(errorCode.name, errorCode.message)
+        val apiResponse = ApiResponse.fail(401, errorResponse)
+        return ResponseEntity.status(401).body(apiResponse)
     }
 
     @ExceptionHandler(Exception::class)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
@@ -29,7 +29,7 @@ class SuggestionController(
         @RequestBody request: SpotSuggestionCreateRequest,
     ): SuggestionImageUrlResponse {
         val suggestion =
-            suggestionService.createSpotSuggestion(
+            suggestionFacade.createSpotSuggestion(
                 SpotSuggestion.Create(
                     userId = user.id,
                     spotName = request.spotName,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportDeleter.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportDeleter.kt
@@ -3,4 +3,10 @@ package com.sseudam.report
 import org.springframework.stereotype.Component
 
 @Component
-class ReportDeleter
+class ReportDeleter(
+    private val reportRepository: SpotReportRepository,
+) {
+    fun deleteBy(reportId: Long) {
+        reportRepository.deleteBy(reportId)
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportService.kt
@@ -15,6 +15,7 @@ class ReportService(
     private val reportAppender: ReportAppender,
     private val reportReader: ReportReader,
     private val reportUpdater: ReportUpdater,
+    private val reportDeleter: ReportDeleter,
     private val txAdvice: TxAdvice,
     private val reportEventPublisher: ReportEventPublisher,
     private val petEventPublisher: PetEventPublisher,
@@ -38,6 +39,7 @@ class ReportService(
             val report = reportUpdater.update(updateReport.reportId, updateReport.status)
             reportEventPublisher.publish(report)
             if (report.status == ReportStatus.APPROVE) {
+                reportDeleter.deleteBy(updateReport.reportId)
                 petEventPublisher.publish(report.userId, PetPointAction.REPORT_APPROVED)
             }
             return@write report

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReportRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReportRepository.kt
@@ -26,4 +26,6 @@ interface SpotReportRepository {
     ): SpotReport.Info
 
     fun existsByName(name: String): Boolean
+
+    fun deleteBy(reportId: Long)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestionRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestionRepository.kt
@@ -28,4 +28,6 @@ interface SpotSuggestionRepository {
     ): SpotSuggestion.Info
 
     fun existsByName(name: String): Boolean
+
+    fun deleteBy(suggestionId: Long)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionDeleter.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionDeleter.kt
@@ -5,4 +5,8 @@ import org.springframework.stereotype.Component
 @Component
 class SuggestionDeleter(
     private val spotSuggestionRepository: SpotSuggestionRepository,
-)
+) {
+    fun deleteBy(suggestionId: Long) {
+        spotSuggestionRepository.deleteBy(suggestionId)
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionFacade.kt
@@ -1,5 +1,6 @@
 package com.sseudam.suggestion
 
+import com.sseudam.common.S3ImageUrl
 import com.sseudam.trashspot.TrashSpotService
 import org.springframework.stereotype.Service
 
@@ -11,7 +12,12 @@ class SuggestionFacade(
     fun validateSpotSuggestion(name: String): Boolean {
         suggestionService.validateSpotSuggestionName(name)
         trashSpotService.validateSpotName(name)
-
         return true
+    }
+
+    fun createSpotSuggestion(create: SpotSuggestion.Create): Pair<SpotSuggestion.Info, S3ImageUrl> {
+        trashSpotService.appendVerifySpot(create.site, create.longitude, create.latitude)
+        val appendSuggestion = suggestionService.append(create)
+        return appendSuggestion.first to appendSuggestion.second
     }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionReader.kt
@@ -2,12 +2,17 @@ package com.sseudam.suggestion
 
 import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.page.Page
+import org.locationtech.jts.geom.GeometryFactory
 import org.springframework.stereotype.Component
 
 @Component
 class SuggestionReader(
     private val spotSuggestionRepository: SpotSuggestionRepository,
 ) {
+    companion object {
+        private val GEOMETRY_FACTORY = GeometryFactory()
+    }
+
     fun readBy(suggestionId: Long): SpotSuggestion.Info = spotSuggestionRepository.findBy(suggestionId)
 
     fun readAllByUser(userId: Long): List<SpotSuggestion.Info> = spotSuggestionRepository.findAllByUserId(userId)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -18,6 +18,7 @@ class SuggestionService(
     private val suggestionAppender: SuggestionAppender,
     private val suggestionReader: SuggestionReader,
     private val suggestionUpdater: SuggestionUpdater,
+    private val suggestionDeleter: SuggestionDeleter,
     private val suggestionValidator: SuggestionValidator,
     private val suggestionEventPublisher: SuggestionEventPublisher,
     private val txAdvice: TxAdvice,
@@ -56,6 +57,7 @@ class SuggestionService(
             val suggestion = suggestionUpdater.update(suggestionId, status)
             suggestionEventPublisher.publish(suggestion)
             if (suggestion.status == SuggestionStatus.APPROVE) {
+                suggestionDeleter.deleteBy(suggestionId)
                 petEventPublisher.publish(suggestion.userId, PetPointAction.SUGGESTION_APPROVED)
             }
             return@write suggestion

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -18,8 +18,9 @@ class SuggestionService(
     private val suggestionAppender: SuggestionAppender,
     private val suggestionReader: SuggestionReader,
     private val suggestionUpdater: SuggestionUpdater,
-    private val txAdvice: TxAdvice,
+    private val suggestionValidator: SuggestionValidator,
     private val suggestionEventPublisher: SuggestionEventPublisher,
+    private val txAdvice: TxAdvice,
     private val petEventPublisher: PetEventPublisher,
     private val imageS3Caller: ImageS3Caller,
 ) {
@@ -27,10 +28,12 @@ class SuggestionService(
         private const val SUGGESTION_IMAGE_PATH = "suggestion"
     }
 
-    fun createSpotSuggestion(suggestion: SpotSuggestion.Create): Pair<SpotSuggestion.Info, S3ImageUrl> {
-        val uploadUrl = imageS3Caller.createUploadUrl(suggestion.userId, LocalDateTime.now(), SUGGESTION_IMAGE_PATH)
-        val spotSuggestion = suggestionAppender.append(uploadUrl.imageUrl, suggestion)
-        petEventPublisher.publish(suggestion.userId, PetPointAction.SUGGESTION)
+    fun append(create: SpotSuggestion.Create): Pair<SpotSuggestion.Info, S3ImageUrl> {
+        suggestionValidator.verifySite(create.site)
+
+        val uploadUrl = imageS3Caller.createUploadUrl(create.userId, LocalDateTime.now(), SUGGESTION_IMAGE_PATH)
+        val spotSuggestion = suggestionAppender.append(uploadUrl.imageUrl, create)
+        petEventPublisher.publish(create.userId, PetPointAction.SUGGESTION)
         return spotSuggestion to uploadUrl
     }
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionValidator.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionValidator.kt
@@ -1,0 +1,17 @@
+package com.sseudam.suggestion
+
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
+import org.springframework.stereotype.Component
+
+@Component
+class SuggestionValidator(
+    private val suggestionRepository: SpotSuggestionRepository,
+) {
+    fun verifySite(site: String) {
+        val suggestion = suggestionRepository.findBySite(site)
+        if (suggestion != null) {
+            throw ErrorException(ErrorType.ALREADY_EXIST_SUGGESTION_SPOT_SITE)
+        }
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
@@ -126,4 +126,26 @@ enum class ErrorType(
         "펫 생성에 실패했습니다.",
         ErrorLevel.ERROR,
     ),
+
+    /** Suggestion */
+    ALREADY_EXIST_SUGGESTION_SPOT_SITE(
+        409,
+        ErrorKind.CLIENT_ERROR,
+        "이미 존재하는 쓰레기통 장소입니다.",
+        ErrorLevel.WARN,
+    ),
+
+    /** SPOT */
+    ALREADY_EXIST_SPOT_SITE(
+        409,
+        ErrorKind.CLIENT_ERROR,
+        "이미 존재하는 쓰레기통 주소입니다.",
+        ErrorLevel.WARN,
+    ),
+    ALREADY_EXIST_SPOT_POINT(
+        409,
+        ErrorKind.CLIENT_ERROR,
+        "이미 존재하는 쓰레기통 좌표입니다.",
+        ErrorLevel.WARN,
+    ),
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotRepository.kt
@@ -28,6 +28,10 @@ interface TrashSpotRepository {
 
     fun findAllByIds(spotIds: List<Long>): List<TrashSpot.Info>
 
+    fun findBySite(site: String): TrashSpot.Info?
+
+    fun findByPoint(point: Point): TrashSpot.Info?
+
     fun updateName(
         spotId: Long,
         name: String,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
@@ -8,6 +8,8 @@ import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
 import com.sseudam.support.geo.GeoJson
 import com.sseudam.support.geo.Region
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,8 +17,13 @@ class TrashSpotService(
     private val trashSpotReader: TrashSpotReader,
     private val trashSpotAppender: TrashSpotAppender,
     private val trashSpotUpdater: TrashSpotUpdater,
+    private val trashSpotValidator: TrashSpotValidator,
     private val geoConverter: GeoConverter,
 ) {
+    companion object {
+        private val GEOMETRY_FACTORY = GeometryFactory()
+    }
+
     fun createTrashSpotBySuggestion(suggestionInfo: SpotSuggestion.Info): TrashSpot.Info =
         trashSpotAppender.append(
             TrashSpot.Create(
@@ -69,5 +76,19 @@ class TrashSpotService(
         if (trashSpotReader.existsByName(name)) {
             throw ErrorException(ErrorType.DUPLICATE_SPOT_NAME)
         }
+    }
+
+    fun appendVerifySpot(
+        site: String,
+        longitude: Double,
+        latitude: Double,
+    ) {
+        val point =
+            GEOMETRY_FACTORY.createPoint(
+                Coordinate(longitude, latitude),
+            )
+
+        trashSpotValidator.verifySite(site)
+        trashSpotValidator.verifyPoint(point)
     }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotValidator.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotValidator.kt
@@ -1,0 +1,25 @@
+package com.sseudam.trashspot
+
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
+import org.locationtech.jts.geom.Point
+import org.springframework.stereotype.Component
+
+@Component
+class TrashSpotValidator(
+    private val trashSpotRepository: TrashSpotRepository,
+) {
+    fun verifySite(site: String) {
+        val trashSpot = trashSpotRepository.findBySite(site)
+        if (trashSpot != null) {
+            throw ErrorException(ErrorType.ALREADY_EXIST_SPOT_SITE)
+        }
+    }
+
+    fun verifyPoint(point: Point) {
+        val trashSpot = trashSpotRepository.findByPoint(point)
+        if (trashSpot != null) {
+            throw ErrorException(ErrorType.ALREADY_EXIST_SPOT_POINT)
+        }
+    }
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCoreRepository.kt
@@ -4,6 +4,7 @@ import com.sseudam.report.ReportStatus
 import com.sseudam.report.ReportType
 import com.sseudam.report.SpotReport
 import com.sseudam.report.SpotReportRepository
+import com.sseudam.storage.db.core.support.findByIdAndDeletedAtIsNullOrElseThrow
 import com.sseudam.storage.db.core.support.findByIdOrElseThrow
 import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.page.Page
@@ -65,5 +66,11 @@ class SpotReportCoreRepository(
     override fun existsByName(name: String): Boolean =
         txAdvice.readOnly {
             spotReportJpaRepository.existsBySpotName(name)
+        }
+
+    override fun deleteBy(reportId: Long) =
+        txAdvice.write {
+            val report = spotReportJpaRepository.findByIdAndDeletedAtIsNullOrElseThrow(reportId)
+            report.softDelete()
         }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCustomRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCustomRepository.kt
@@ -28,7 +28,7 @@ class SpotReportCustomRepository(
                 select(entity(SpotReportEntity::class))
                     .from(entity(SpotReportEntity::class))
                     .whereAnd(
-                        path(SpotReportEntity::deletedAt).isNull(),
+//                        path(SpotReportEntity::deletedAt).isNull(),
                         searchType?.let {
                             path(SpotReportEntity::reportType).eq(it)
                         },

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
@@ -1,5 +1,6 @@
 package com.sseudam.storage.db.core.suggestion
 
+import com.sseudam.storage.db.core.support.findByIdAndDeletedAtIsNullOrElseThrow
 import com.sseudam.storage.db.core.support.findByIdOrElseThrow
 import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SpotSuggestionRepository
@@ -45,7 +46,7 @@ class SpotSuggestionCoreRepository(
     override fun findBySite(site: String): SpotSuggestion.Info? =
         txAdvice.readOnly {
             spotSuggestionJpaRepository
-                .findByAddressSite(site)
+                .findByAddressSiteAndDeletedAtIsNull(site)
                 ?.toSpotSuggestion()
         }
 
@@ -69,5 +70,11 @@ class SpotSuggestionCoreRepository(
     override fun existsByName(name: String): Boolean =
         txAdvice.readOnly {
             spotSuggestionJpaRepository.existsBySpotName(name)
+        }
+
+    override fun deleteBy(suggestionId: Long) =
+        txAdvice.write {
+            val suggestion = spotSuggestionJpaRepository.findByIdAndDeletedAtIsNullOrElseThrow(suggestionId)
+            suggestion.softDelete()
         }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCustomRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCustomRepository.kt
@@ -29,7 +29,7 @@ class SpotSuggestionCustomRepository(
                 select(entity(SpotSuggestionEntity::class))
                     .from(entity(SpotSuggestionEntity::class))
                     .whereAnd(
-                        path(SpotSuggestionEntity::deletedAt).isNull(),
+//                        path(SpotSuggestionEntity::deletedAt).isNull(),
                         searchStatus?.let {
                             path(SpotSuggestionEntity::status).eq(it)
                         },

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionJpaRepository.kt
@@ -8,7 +8,7 @@ interface SpotSuggestionJpaRepository :
     KotlinJdslJpqlExecutor {
     fun findAllByUserId(userId: Long): List<SpotSuggestionEntity>
 
-    fun findByAddressSite(site: String): SpotSuggestionEntity?
+    fun findByAddressSiteAndDeletedAtIsNull(site: String): SpotSuggestionEntity?
 
     fun existsBySpotName(name: String): Boolean
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotCoreRepository.kt
@@ -99,6 +99,20 @@ class TrashSpotCoreRepository(
                 .map { it.toTrashSpot() }
         }
 
+    override fun findBySite(site: String): TrashSpot.Info? =
+        txAdvice.readOnly {
+            trashSpotJpaRepository
+                .findByAddressSite(site)
+                ?.toTrashSpot()
+        }
+
+    override fun findByPoint(point: Point): TrashSpot.Info? =
+        txAdvice.readOnly {
+            trashSpotJpaRepository
+                .findByPoint(point)
+                ?.toTrashSpot()
+        }
+
     override fun updateName(
         spotId: Long,
         name: String,

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotJpaRepository.kt
@@ -3,6 +3,7 @@ package com.sseudam.storage.db.core.trashspot
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import com.sseudam.support.geo.Region
 import com.sseudam.trashspot.TrashType
+import org.locationtech.jts.geom.Point
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -78,4 +79,8 @@ interface TrashSpotJpaRepository :
     fun findAllByIdIn(spotIds: List<Long>): List<TrashSpotEntity>
 
     fun existsByName(name: String): Boolean
+
+    fun findByAddressSite(site: String): TrashSpotEntity?
+
+    fun findByPoint(point: Point): TrashSpotEntity?
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #141 

## 📌 작업 내용 및 특이 사항

- 1949260d75060b0f3c84d6280db3f8b350149e9b: 중복 검증한다.
- 16af5debc3085a8b62a7b46c50b3c938949d3895: 승인 시 제보 및 신고 내역 soft delete

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent duplicate trash bin suggestions and locations based on site and geographic coordinates.
  * Introduced new error messages for already existing trash bin locations and suggestions.
  * Added ability to delete spot suggestions and reports upon approval.

* **Bug Fixes**
  * Improved soft-delete handling for suggestions and reports, ensuring deleted items are properly filtered or included as needed.

* **Enhancements**
  * Enhanced suggestion and trash spot creation workflows with additional validation and verification steps.
  * Improved error handling for authentication errors with more specific responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->