### PR TITLE
[Refactor] UserPet soft-delete by user withdrawal

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/user/UserController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/user/UserController.kt
@@ -1,6 +1,5 @@
 package com.sseudam.presentation.v1.user
 
-import com.sseudam.auth.AuthenticationService
 import com.sseudam.presentation.v1.annotation.ApiV1Controller
 import com.sseudam.presentation.v1.user.request.NicknameRequest
 import com.sseudam.presentation.v1.user.request.UserMobileDeviceRequest
@@ -9,8 +8,8 @@ import com.sseudam.presentation.v1.user.response.UserMobileDeviceResponse
 import com.sseudam.presentation.v1.user.response.UserProfileResponse
 import com.sseudam.presentation.v1.user.response.UserWithdrawalResponse
 import com.sseudam.support.error.ErrorException
-import com.sseudam.user.NewUserWithdrawal
 import com.sseudam.user.User
+import com.sseudam.user.UserFacade
 import com.sseudam.user.UserService
 import com.sseudam.user.device.UserDeviceService
 import io.swagger.v3.oas.annotations.Operation
@@ -27,8 +26,8 @@ import org.springframework.web.bind.annotation.RequestHeader
 @ApiV1Controller
 class UserController(
     private val userService: UserService,
+    private val userFacade: UserFacade,
     private val userDeviceService: UserDeviceService,
-    private val authenticationService: AuthenticationService,
 ) {
     @Operation(summary = "내 정보 조회", description = "내 정보를 조회합니다.")
     @GetMapping("/users/me")
@@ -44,12 +43,7 @@ class UserController(
     fun withdrawal(
         @Parameter(hidden = true, required = false) user: User,
     ): UserWithdrawalResponse {
-        userService.deleteUser(
-            NewUserWithdrawal(
-                user = user,
-            ),
-        )
-        authenticationService.withdrawUser(user.key)
+        userFacade.withdrawalUser(user)
         return UserWithdrawalResponse("회원탈퇴가 완료되었습니다.")
     }
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetDeleter.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetDeleter.kt
@@ -9,4 +9,8 @@ class UserPetDeleter(
     fun deleteAllByUserIds(userIds: List<Long>) {
         userPetRepository.deleteAllByUserIds(userIds)
     }
+
+    fun deleteByUser(userId: Long) {
+        userPetRepository.deleteByUserId(userId)
+    }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetRepository.kt
@@ -32,4 +32,6 @@ interface UserPetRepository {
     fun initPoint(petId: Long)
 
     fun deleteAllByUserIds(userIds: List<Long>)
+
+    fun deleteByUserId(userId: Long)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetService.kt
@@ -45,4 +45,8 @@ class UserPetService(
         userPetDeleter.deleteAllByUserIds(userIds)
         userPetAppender.appendAll(userPets, petId)
     }
+
+    fun deleteByUser(userId: Long) {
+        userPetDeleter.deleteByUser(userId)
+    }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserFacade.kt
@@ -1,0 +1,22 @@
+package com.sseudam.user
+
+import com.sseudam.auth.AuthenticationService
+import com.sseudam.pet.UserPetService
+import org.springframework.stereotype.Service
+
+@Service
+class UserFacade(
+    private val userService: UserService,
+    private val authenticationService: AuthenticationService,
+    private val userPetService: UserPetService,
+) {
+    fun withdrawalUser(user: User) {
+        userPetService.deleteByUser(user.id)
+        userService.deleteUser(
+            NewUserWithdrawal(
+                user = user,
+            ),
+        )
+        authenticationService.withdrawUser(user.key)
+    }
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
@@ -98,4 +98,12 @@ class UserPetCoreRepository(
             userPetCustomRepository.softDeleteAllByUserIds(userIds)
         }
     }
+
+    override fun deleteByUserId(userId: Long) =
+        txAdvice.write {
+            val userPet =
+                userPetJpaRepository.findByUserIdAndDeletedAtIsNull(userId)
+                    ?: throw ErrorException(ErrorType.NOT_FOUND_DATA)
+            userPet.softDelete()
+        }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #145 

## 📌 작업 내용 및 특이 사항

- 236d598ceaa7fe5a53979dcadf5d74faee9850d7: 회원탈퇴 시 사용자 펫 정보 soft-delete

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete pets associated with a specific user during user withdrawal.
  * Introduced a new service to coordinate user withdrawal operations, ensuring all related data is properly removed.

* **Bug Fixes**
  * Improved the user withdrawal process to ensure associated pet data is consistently deleted.

* **Refactor**
  * Streamlined the user withdrawal workflow for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->