### PR TITLE
[Refactor] User pet season response field

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
@@ -1,5 +1,6 @@
 package com.sseudam.presentation.v1.pet
 
+import com.sseudam.pet.PetService
 import com.sseudam.pet.UserPetFacade
 import com.sseudam.pet.UserPetPolicy
 import com.sseudam.pet.UserPetService
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody
 @Tag(name = "😽 Pet API", description = "펫 관련 API")
 @ApiV1Controller
 class PetController(
+    private val petService: PetService,
     private val userPetService: UserPetService,
     private val userPetFacade: UserPetFacade,
     private val userPetPolicy: UserPetPolicy,
@@ -25,10 +27,14 @@ class PetController(
     @Operation(summary = "펫 정보 조회", description = "사용자의 펫 정보를 조회합니다.")
     @GetMapping("/pets")
     fun findUserPetInfo(user: User): UserPetInfoResponse {
-        val petInfo = userPetFacade.findPetInfo(user.id)
-        val petLevel = userPetPolicy.getLevelType(petInfo.point)
+        val userPetInfo = userPetFacade.findPetInfo(user.id)
+        val petInfo = petService.findBy(userPetInfo.petId)
+
+        val petLevel = userPetPolicy.getLevelType(userPetInfo.point)
         val maxLevelStandard = userPetPolicy.getMaxLevelStandard(petLevel)
-        return UserPetInfoResponse.of(petInfo, petLevel, maxLevelStandard)
+        val userPetSeason = userPetPolicy.getSeasonByPetInfo(petInfo)
+
+        return UserPetInfoResponse.of(userPetInfo, petLevel, userPetSeason, maxLevelStandard)
     }
 
     @Operation(summary = "펫 이름 변경", description = "사용자 펫의 이름을 변경합니다.")
@@ -39,19 +45,26 @@ class PetController(
         request: UpdateUserPetNameRequest,
     ): UserPetInfoResponse {
         val updatedPetInfo = userPetService.updatePetName(user.id, request.nickname)
+        val petInfo = petService.findBy(updatedPetInfo.petId)
+
         val petLevel = userPetPolicy.getLevelType(updatedPetInfo.point)
         val maxLevelStandard = userPetPolicy.getMaxLevelStandard(petLevel)
-        return UserPetInfoResponse.of(updatedPetInfo, petLevel, maxLevelStandard)
+        val userPetSeason = userPetPolicy.getSeasonByPetInfo(petInfo)
+
+        return UserPetInfoResponse.of(updatedPetInfo, petLevel, userPetSeason, maxLevelStandard)
     }
 
     @Operation(summary = "현 시즌 펫 성장 기록 조회", description = "사용자의 현 시즌 펫 성장 기록을 조회합니다.")
     @GetMapping("/pets/season")
     fun findUserPetSeasonInfo(user: User): UserPetLevelHistoryCurrentSeasonAllResponse {
         val seasonHistory = userPetFacade.findCurrentSeasonPetHistory(user.id)
+        val petInfo = petService.findBy(seasonHistory.first.petId)
+
         val petLevel = userPetPolicy.getLevelType(seasonHistory.first.point)
         val maxLevelStandard = userPetPolicy.getMaxLevelStandard(petLevel)
+        val season = userPetPolicy.getSeasonByPetInfo(petInfo)
         return UserPetLevelHistoryCurrentSeasonAllResponse.of(
-            UserPetInfoResponse.of(seasonHistory.first, petLevel, maxLevelStandard),
+            UserPetInfoResponse.of(seasonHistory.first, petLevel, season, maxLevelStandard),
             seasonHistory.second,
         )
     }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetInfoResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetInfoResponse.kt
@@ -2,21 +2,33 @@ package com.sseudam.presentation.v1.pet.response
 
 import com.sseudam.pet.Pet
 import com.sseudam.pet.UserPet
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
+@Schema(description = "사용자 펫 응답 Json")
 data class UserPetInfoResponse(
+    @Schema(description = "사용자 ID", example = "1")
     val userId: Long,
+    @Schema(description = "펫 ID", example = "1")
     val petId: Long,
+    @Schema(description = "펫 닉네임", example = "사용자 펫 닉네임")
     val nickname: String,
+    @Schema(description = "펫 포인트", example = "235")
     val point: Long,
+    @Schema(description = "레벨 타입", example = "LEVEL_1")
     val levelType: Pet.LevelType,
+    @Schema(description = "레벨 최대 포인트 기준", example = "20")
     val maxLevelStandard: Long,
+    @Schema(description = "현 시즌", example = "2025-07")
+    val season: String,
+    @Schema(description = "생성 일자", example = "2025-07-05T12:00:00")
     val createdAt: LocalDateTime,
 ) {
     companion object {
         fun of(
             userPetInfo: UserPet.Info,
             levelType: Pet.LevelType,
+            season: String,
             maxLevelStandard: Long,
         ): UserPetInfoResponse =
             UserPetInfoResponse(
@@ -26,6 +38,7 @@ data class UserPetInfoResponse(
                 point = userPetInfo.point,
                 levelType = levelType,
                 maxLevelStandard = maxLevelStandard,
+                season = season,
                 createdAt = userPetInfo.createdAt,
             )
     }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryCurrentResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryCurrentResponse.kt
@@ -21,7 +21,7 @@ data class UserPetLevelHistoryCurrentResponse(
                 point = history.point,
                 levelType = history.levelType,
                 isLocked = history.isLocked,
-                season = "%04d-%02d".format(history.year, history.month.value),
+                season = history.season,
                 createdAt = history.createdAt,
             )
     }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/response/UserPetLevelHistoryResponse.kt
@@ -19,7 +19,7 @@ data class UserPetLevelHistoryResponse(
                 nickname = history.nickname,
                 point = history.point,
                 levelType = history.levelType,
-                season = "%04d-%02d".format(history.year, history.month.value),
+                season = history.season,
                 createdAt = history.createdAt,
             )
     }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
@@ -50,8 +50,7 @@ class UserPetFacade(
                     levelType = petInfo.levelType,
                     point = pointStandard,
                     isLocked = userPetInfo.point <= pointStandard,
-                    year = currentYear,
-                    month = currentMonth,
+                    season = userPetPolicy.getSeasonByYearMonth(history?.year ?: currentYear, history?.monthly ?: currentMonth),
                     createdAt =
                         if (petInfo.levelType == Pet.LevelType.LEVEL_1) {
                             LocalDateTime.of(currentYear, currentMonth, 1, 0, 0)
@@ -83,8 +82,7 @@ class UserPetFacade(
                     nickname = history.levelType.adjective + history.nickname,
                     levelType = history.levelType,
                     point = userPetPolicy.getMinLevelStandard(history.levelType),
-                    year = history.year,
-                    month = history.monthly,
+                    season = userPetPolicy.getSeasonByYearMonth(history.year, history.monthly),
                     createdAt = history.createdAt,
                 )
             }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetLevelUpCurrentSeasonHistoryInfo.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetLevelUpCurrentSeasonHistoryInfo.kt
@@ -1,7 +1,6 @@
 package com.sseudam.pet
 
 import java.time.LocalDateTime
-import java.time.Month
 
 data class UserPetLevelUpCurrentSeasonHistoryInfo(
     val userId: Long,
@@ -9,7 +8,6 @@ data class UserPetLevelUpCurrentSeasonHistoryInfo(
     val levelType: Pet.LevelType,
     val point: Long,
     val isLocked: Boolean,
-    val year: Int,
-    val month: Month,
+    val season: String,
     val createdAt: LocalDateTime,
 )

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetLevelUpHistoryInfo.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetLevelUpHistoryInfo.kt
@@ -1,14 +1,12 @@
 package com.sseudam.pet
 
 import java.time.LocalDateTime
-import java.time.Month
 
 data class UserPetLevelUpHistoryInfo(
     val userId: Long,
     val nickname: String,
     val levelType: Pet.LevelType,
     val point: Long,
-    val year: Int,
-    val month: Month,
+    val season: String,
     val createdAt: LocalDateTime,
 )

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetPolicy.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetPolicy.kt
@@ -3,6 +3,7 @@ package com.sseudam.pet
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
 import org.springframework.stereotype.Component
+import java.time.Month
 
 @Component
 class UserPetPolicy {
@@ -33,4 +34,11 @@ class UserPetPolicy {
             Pet.LevelType.LEVEL_4 -> LevelStandard.LEVEL_4_MIN.toLong()
             Pet.LevelType.SPECIAL -> LevelStandard.SPECIAL_MIN.toLong()
         }
+
+    fun getSeasonByPetInfo(petInfo: Pet.Info): String = "%04d-%02d".format(petInfo.year, petInfo.monthly.value)
+
+    fun getSeasonByYearMonth(
+        year: Int,
+        month: Month,
+    ): String = "%04d-%02d".format(year, month.value)
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #147 

## 📌 작업 내용 및 특이 사항

- 59a139e20a8fc36881f399d23ae0ad99fc5636f5: 현재 사용자 펫에 대한 현 시즌 응답 필드 추가

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added season information to pet-related responses, providing clearer context about the pet's current season.
  * Enhanced API documentation with detailed descriptions and example values for pet info responses.

* **Refactor**
  * Simplified the representation of time periods in pet history from separate year and month fields to a single season string across pet-related data and responses.

* **Bug Fixes**
  * Improved consistency in how season information is constructed and displayed throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->