### PR TITLE
[Fix] Report default image url

### DIFF
--- a/sseudam-clients/aws/src/main/kotlin/com/sseudam/image/ImageFileConstructor.kt
+++ b/sseudam-clients/aws/src/main/kotlin/com/sseudam/image/ImageFileConstructor.kt
@@ -2,8 +2,6 @@ package com.sseudam.image
 
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
-import java.time.LocalDateTime
-import java.time.ZoneId
 import java.util.Random
 
 @Component
@@ -21,12 +19,10 @@ class ImageFileConstructor(
 
     fun imageFilePath(
         userId: Long,
-        dateTime: LocalDateTime,
         prefix: String,
     ): String {
         val profile = environment.activeProfiles.firstOrNull() ?: "dev"
-        val dateTimeToLong = dateTime.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli()
-        return "$profile/$prefix/$userId/$dateTimeToLong"
+        return "$profile/$prefix/$userId"
     }
 
     private fun randomFileName(): String =

--- a/sseudam-clients/aws/src/main/kotlin/com/sseudam/image/ImageS3Processor.kt
+++ b/sseudam-clients/aws/src/main/kotlin/com/sseudam/image/ImageS3Processor.kt
@@ -6,7 +6,6 @@ import com.sseudam.config.AwsProperties
 import com.sseudam.s3.AwsS3Client
 import org.springframework.stereotype.Component
 import java.time.Duration
-import java.time.LocalDateTime
 
 @Component
 class ImageS3Processor(
@@ -20,10 +19,9 @@ class ImageS3Processor(
 
     override fun createUploadUrl(
         userId: Long,
-        dateTime: LocalDateTime,
         prefix: String,
     ): S3ImageUrl {
-        val imageFilePath = imageFileConstructor.imageFilePath(userId, dateTime, prefix)
+        val imageFilePath = imageFileConstructor.imageFilePath(userId, prefix)
         val imageFileName = imageFileConstructor.imageFileName()
 
         val presignedUrl =

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/jwt/JwtProvider.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/jwt/JwtProvider.kt
@@ -16,6 +16,8 @@ import com.sseudam.auth.token.repository.TokenRepository
 import com.sseudam.config.AuthenticationProperties
 import com.sseudam.support.error.AuthenticationErrorException
 import com.sseudam.support.error.AuthenticationErrorType
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
 import com.sseudam.user.SocialUser
 import com.sseudam.user.User
 import org.springframework.security.authentication.AuthenticationServiceException
@@ -29,7 +31,6 @@ import org.springframework.security.oauth2.jwt.JwtException
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException
 import org.springframework.stereotype.Component
 import java.time.Instant
-import javax.naming.AuthenticationException
 
 @Component
 class JwtProvider(
@@ -253,12 +254,11 @@ class JwtProvider(
 
     override fun findBy(accessToken: String): Provider? = redisTokenRepository.findBy(accessToken)
 
-    @Throws(AuthenticationException::class)
     fun validateToken(token: String): Jwt =
         try {
             jwtDecoder.decode(token)
         } catch (exception: BadJwtException) {
-            throw AuthenticationErrorException(AuthenticationErrorType.INVALID_TOKEN)
+            throw ErrorException(ErrorType.INVALID_TOKEN)
         } catch (exception: JwtException) {
             throw AuthenticationServiceException(exception.message, exception)
         }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
@@ -8,8 +8,6 @@ import com.sseudam.presentation.v1.report.response.ReportValidationResponse
 import com.sseudam.presentation.v1.report.response.SpotReportAllResponse
 import com.sseudam.report.ReportFacade
 import com.sseudam.report.ReportService
-import com.sseudam.report.SpotReport
-import com.sseudam.support.geo.Region
 import com.sseudam.user.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -31,22 +29,7 @@ class ReportController(
         @PathVariable spotId: Long,
         @RequestBody request: SpotReportCreateRequest,
     ): ReportImageUrlResponse {
-        val report =
-            reportFacade.createSpotReport(
-                create =
-                    SpotReport.Create(
-                        userId = user.id,
-                        spotId = spotId,
-                        reportType = request.reportType,
-                        latitude = request.latitude,
-                        longitude = request.longitude,
-                        spotName = request.spotName,
-                        region = request.region ?: Region.UNKNOWN,
-                        city = request.city,
-                        site = request.site,
-                        trashType = request.trashType,
-                    ),
-            )
+        val report = reportFacade.createSpotReport(create = request.toCommand(user.id, spotId))
         return ReportImageUrlResponse.of(
             report = report.first,
             presignedUrl = report.second,

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/SpotReportCreateRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/SpotReportCreateRequest.kt
@@ -1,14 +1,13 @@
 package com.sseudam.presentation.v1.report.request
 
 import com.sseudam.report.ReportType
+import com.sseudam.report.SpotReport
 import com.sseudam.support.geo.Region
 import com.sseudam.trashspot.TrashType
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "신고하기 요청 Json")
 data class SpotReportCreateRequest(
-    @Schema(description = "장소 ID", example = "1")
-    val spotId: Long,
     @Schema(description = "신고 타입", example = "POINT")
     val reportType: ReportType,
     @Schema(description = "위도", example = "37.566535")
@@ -25,4 +24,21 @@ data class SpotReportCreateRequest(
     val site: String,
     @Schema(description = "쓰레기통 유형", example = "GENERAL")
     val trashType: TrashType,
-)
+) {
+    fun toCommand(
+        userId: Long,
+        spotId: Long,
+    ): SpotReport.Create =
+        SpotReport.Create(
+            userId = userId,
+            spotId = spotId,
+            reportType = reportType,
+            latitude = latitude,
+            longitude = longitude,
+            spotName = spotName,
+            region = region ?: Region.UNKNOWN,
+            city = city,
+            site = site,
+            trashType = trashType,
+        )
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/common/ImageS3Caller.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/common/ImageS3Caller.kt
@@ -1,11 +1,8 @@
 package com.sseudam.common
 
-import java.time.LocalDateTime
-
 interface ImageS3Caller {
     fun createUploadUrl(
         userId: Long,
-        dateTime: LocalDateTime,
         prefix: String,
     ): S3ImageUrl
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportFacade.kt
@@ -4,13 +4,10 @@ import com.sseudam.common.ImageS3Caller
 import com.sseudam.common.S3ImageUrl
 import com.sseudam.pet.PetPointAction
 import com.sseudam.pet.event.PetEventPublisher
-import com.sseudam.support.error.ErrorException
-import com.sseudam.support.error.ErrorType
 import com.sseudam.support.tx.TxAdvice
 import com.sseudam.trashspot.TrashSpotService
 import com.sseudam.trashspot.image.TrashSpotImageService
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
 
 @Service
 class ReportFacade(
@@ -23,6 +20,7 @@ class ReportFacade(
 ) {
     companion object {
         private const val REPORT_IMAGE_PATH = "report"
+        private const val DEFAULT_REPORT_IMAGE_URL = "https://img.sseudam.me/dev/default_trash_profile.webp"
     }
 
     fun validateSpotReport(name: String): Boolean {
@@ -40,10 +38,9 @@ class ReportFacade(
                 images
                     .filter { it.updatedAt != null }
                     .maxByOrNull { it.updatedAt!! }
-                    ?.imageUrl
-                    ?: throw ErrorException(ErrorType.NOT_FOUND_DATA)
+                    ?.imageUrl ?: DEFAULT_REPORT_IMAGE_URL
             if (create.reportType == ReportType.PHOTO) {
-                val s3ImageUrl: S3ImageUrl = imageS3Caller.createUploadUrl(create.userId, LocalDateTime.now(), REPORT_IMAGE_PATH)
+                val s3ImageUrl: S3ImageUrl = imageS3Caller.createUploadUrl(create.userId, REPORT_IMAGE_PATH + "/${create.spotId}")
                 presignedUrl = s3ImageUrl.presignedUrl
                 imageUrl = s3ImageUrl.imageUrl
             } else {

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -11,7 +11,6 @@ import com.sseudam.support.error.ErrorType
 import com.sseudam.support.page.Page
 import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
 
 @Service
 class SuggestionService(
@@ -33,7 +32,7 @@ class SuggestionService(
         txAdvice.write {
             suggestionValidator.verifySite(create.site)
 
-            val uploadUrl = imageS3Caller.createUploadUrl(create.userId, LocalDateTime.now(), SUGGESTION_IMAGE_PATH)
+            val uploadUrl = imageS3Caller.createUploadUrl(create.userId, SUGGESTION_IMAGE_PATH)
             val spotSuggestion = suggestionAppender.append(uploadUrl.imageUrl, create)
             petEventPublisher.publish(create.userId, PetPointAction.SUGGESTION)
             return@write spotSuggestion to uploadUrl


### PR DESCRIPTION
## 🌱 관련 이슈
- close #155 

## 📌 작업 내용 및 특이 사항

- fd285954241ce60094e50c1416fb42ff171ee8d8: default 이미지 경로로 return 
- 이미지 prefix 변경

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified image upload: presigned URL endpoints no longer require a timestamp; report photos use spot-based paths.
- Bug Fixes
  - Missing report images now display a default placeholder instead of failing.
  - Invalid tokens return a consistent “INVALID_TOKEN” error response.
- Refactor
  - Report creation: request body no longer includes spotId; it’s derived from the endpoint path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->