### PR TITLE
[Feature] App version API

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/version/app/AppVersionController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/version/app/AppVersionController.kt
@@ -1,0 +1,22 @@
+package com.sseudam.presentation.v1.version.app
+
+import com.sseudam.common.DeviceType
+import com.sseudam.presentation.v1.annotation.ApiV1Controller
+import com.sseudam.presentation.v1.version.app.response.AppVersionResponse
+import com.sseudam.version.app.AppVersionService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "📱 AppVersion API", description = "앱 버전 관련 API입니다.")
+@ApiV1Controller
+class AppVersionController(
+    private val appVersionService: AppVersionService,
+) {
+    @Operation(summary = "앱 버전 조회", description = "앱 버전에 대한 조회를 합니다.")
+    @GetMapping("/versions/app")
+    fun appVersionFind(
+        @RequestParam deviceType: DeviceType,
+    ): AppVersionResponse = AppVersionResponse.from(appVersionService.getAppVersion(deviceType))
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/version/app/response/AppVersionResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/version/app/response/AppVersionResponse.kt
@@ -2,9 +2,13 @@ package com.sseudam.presentation.v1.version.app.response
 
 import com.sseudam.common.DeviceType
 import com.sseudam.version.app.AppVersion
+import io.swagger.v3.oas.annotations.media.Schema
 
+@Schema(description = "앱 버전 조회 응답 Json")
 data class AppVersionResponse(
+    @Schema(description = "앱 OS", example = "IOS")
     val deviceType: DeviceType,
+    @Schema(description = "버전", example = "1.0.0")
     val version: String,
 ) {
     companion object {

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/version/app/response/AppVersionResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/version/app/response/AppVersionResponse.kt
@@ -1,0 +1,19 @@
+package com.sseudam.presentation.v1.version.app.response
+
+import com.sseudam.common.DeviceType
+import com.sseudam.version.app.AppVersion
+
+data class AppVersionResponse(
+    val deviceType: DeviceType,
+    val version: String,
+) {
+    companion object {
+        fun from(appVersion: AppVersion): AppVersionResponse =
+            with(appVersion) {
+                AppVersionResponse(
+                    deviceType = deviceType,
+                    version = version,
+                )
+            }
+    }
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/common/DeviceType.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/common/DeviceType.kt
@@ -1,0 +1,6 @@
+package com.sseudam.common
+
+enum class DeviceType {
+    IOS,
+    ANDROID,
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersion.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersion.kt
@@ -1,0 +1,8 @@
+package com.sseudam.version.app
+
+import com.sseudam.common.DeviceType
+
+data class AppVersion(
+    val deviceType: DeviceType,
+    val version: String,
+)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersionReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersionReader.kt
@@ -1,0 +1,17 @@
+package com.sseudam.version.app
+
+import com.sseudam.common.DeviceType
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
+import org.springframework.stereotype.Component
+
+@Component
+class AppVersionReader(
+    private val appVersionRepository: AppVersionRepository,
+) {
+    fun readByDeviceType(deviceType: DeviceType): AppVersion =
+        appVersionRepository.findByDeviceType(deviceType) ?: throw ErrorException(
+            errorType = ErrorType.NOT_FOUND_DATA,
+            data = deviceType,
+        )
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersionRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersionRepository.kt
@@ -1,0 +1,7 @@
+package com.sseudam.version.app
+
+import com.sseudam.common.DeviceType
+
+interface AppVersionRepository {
+    fun findByDeviceType(deviceType: DeviceType): AppVersion?
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersionService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/version/app/AppVersionService.kt
@@ -1,0 +1,11 @@
+package com.sseudam.version.app
+
+import com.sseudam.common.DeviceType
+import org.springframework.stereotype.Service
+
+@Service
+class AppVersionService(
+    private val appVersionReader: AppVersionReader,
+) {
+    fun getAppVersion(deviceType: DeviceType): AppVersion = appVersionReader.readByDeviceType(deviceType)
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/version/app/AppVersionCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/version/app/AppVersionCoreRepository.kt
@@ -1,0 +1,18 @@
+package com.sseudam.storage.db.core.version.app
+
+import com.sseudam.common.DeviceType
+import com.sseudam.support.tx.TxAdvice
+import com.sseudam.version.app.AppVersion
+import com.sseudam.version.app.AppVersionRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class AppVersionCoreRepository(
+    private val appVersionJpaRepository: AppVersionJpaRepository,
+    private val txAdvice: TxAdvice,
+) : AppVersionRepository {
+    override fun findByDeviceType(deviceType: DeviceType): AppVersion? =
+        txAdvice.readOnly {
+            appVersionJpaRepository.findByDeviceType(deviceType)?.toAppVersion()
+        }
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/version/app/AppVersionEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/version/app/AppVersionEntity.kt
@@ -1,0 +1,25 @@
+package com.sseudam.storage.db.core.version.app
+
+import com.sseudam.common.DeviceType
+import com.sseudam.storage.db.core.support.BaseEntity
+import com.sseudam.version.app.AppVersion
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "t_app_version")
+class AppVersionEntity(
+    @Enumerated(value = EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
+    val deviceType: DeviceType,
+    val version: String,
+) : BaseEntity() {
+    fun toAppVersion(): AppVersion =
+        AppVersion(
+            deviceType = deviceType,
+            version = version,
+        )
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/version/app/AppVersionJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/version/app/AppVersionJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.sseudam.storage.db.core.version.app
+
+import com.sseudam.common.DeviceType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AppVersionJpaRepository : JpaRepository<AppVersionEntity, Long> {
+    fun findByDeviceType(deviceType: DeviceType): AppVersionEntity?
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #159 

## 📌 작업 내용 및 특이 사항

- 7fe559e049850a7f3f1f2a559bf65200772fae4c: App version Definition
- 42889c0c1a804eddc9cae0163e50891b167cb3f2: Response Swagger

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an API endpoint to retrieve the current app version by device type (iOS or Android): GET /versions/app?deviceType=IOS|ANDROID. The response includes deviceType and version.
  - Returns a not-found error when no version is available for the specified device type.

- Documentation
  - The new endpoint is documented in the API specification for discovery and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->