### PR TITLE
[Fix&Refactor]: Remove deleteBy method & Update suggestion, report

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -9,6 +9,8 @@ import com.sseudam.notification.NewFirebaseCloudMessage
 import com.sseudam.notification.NotificationService
 import com.sseudam.notification.NotificationStored
 import com.sseudam.notification.ReadStatus
+import com.sseudam.pet.PetPointAction
+import com.sseudam.pet.event.PetEventPublisher
 import com.sseudam.report.ReportFacade
 import com.sseudam.report.ReportService
 import com.sseudam.report.ReportType
@@ -17,11 +19,16 @@ import com.sseudam.report.UpdateReport
 import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SuggestionService
 import com.sseudam.suggestion.SuggestionStatus
+import com.sseudam.suggestion.event.SuggestionEventPublisher
+import com.sseudam.support.CacheRepository
 import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
 import com.sseudam.support.page.Page
+import com.sseudam.support.tx.TxAdvice
 import com.sseudam.trashspot.TrashSpotService
+import com.sseudam.trashspot.image.TrashSpotImage
+import com.sseudam.trashspot.image.TrashSpotImageService
 import com.sseudam.user.UserProfile
 import com.sseudam.user.UserService
 import com.sseudam.user.device.UserDeviceService
@@ -43,7 +50,16 @@ class AdminFacade(
     private val notificationService: NotificationService,
     private val passwordEncoder: PasswordEncoder,
     private val reportFacade: ReportFacade,
+    private val cacheRepository: CacheRepository,
+    private val trashSpotImageService: TrashSpotImageService,
+    private val petEventPublisher: PetEventPublisher,
+    private val suggestionEventPublisher: SuggestionEventPublisher,
+    private val txAdvice: TxAdvice,
 ) {
+    companion object {
+        private const val SPOT_DETAIL_CACHE_KEY_PREFIX = "spot:detail:"
+    }
+
     fun login(
         loginId: String,
         password: String,
@@ -96,9 +112,31 @@ class AdminFacade(
     fun updateSpotSuggestionStatus(
         suggestionId: Long,
         status: SuggestionStatus,
-    ): SpotSuggestion.Info = suggestionService.updateSuggestion(suggestionId, status)
+    ): SpotSuggestion.UpdateResult =
+        txAdvice.write {
+            val suggestion = suggestionService.updateStatus(suggestionId, status)
+            val spotId: Long =
+                if (suggestion.status == SuggestionStatus.APPROVE) {
+                    val trashSpot = trashSpotService.createTrashSpotBySuggestion(suggestion)
+                    trashSpotImageService.append(
+                        TrashSpotImage.Create(trashSpot.id, suggestion.imageUrl),
+                    )
+                    petEventPublisher.publish(suggestion.userId, PetPointAction.SUGGESTION_APPROVED)
+                    cacheRepository.delete(SPOT_DETAIL_CACHE_KEY_PREFIX + trashSpot.id)
+                    trashSpot.id
+                } else {
+                    0L
+                }
 
-    fun updateSpotReportStatus(updateReport: UpdateReport): SpotReport.Info = reportService.updateSpotReport(updateReport)
+            suggestionEventPublisher.publish(suggestion)
+            return@write SpotSuggestion.UpdateResult.of(suggestion, spotId)
+        }
+
+    fun updateSpotReportStatus(updateReport: UpdateReport): SpotReport.Info {
+        val spotReportInfo = reportService.updateSpotReport(updateReport)
+        cacheRepository.delete(SPOT_DETAIL_CACHE_KEY_PREFIX + spotReportInfo.spotId)
+        return spotReportInfo
+    }
 
     fun pushToAllUsers(
         topic: String,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestion.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestion.kt
@@ -54,4 +54,37 @@ class SpotSuggestion {
         val status: SuggestionStatus = SuggestionStatus.WAITING,
         val createdAt: LocalDateTime,
     )
+
+    data class UpdateResult(
+        val id: Long,
+        val spotId: Long,
+        val userId: Long,
+        val spotName: String,
+        val point: GeoJson,
+        val region: Region,
+        val address: Address,
+        val trashType: TrashType,
+        val imageUrl: String,
+        val status: SuggestionStatus = SuggestionStatus.WAITING,
+        val createdAt: LocalDateTime,
+    ) {
+        companion object {
+            fun of(
+                suggestionInfo: Info,
+                spotId: Long,
+            ) = UpdateResult(
+                id = suggestionInfo.id,
+                spotId = spotId,
+                userId = suggestionInfo.userId,
+                spotName = suggestionInfo.spotName,
+                point = suggestionInfo.point,
+                region = suggestionInfo.region,
+                address = suggestionInfo.address,
+                trashType = suggestionInfo.trashType,
+                imageUrl = suggestionInfo.imageUrl,
+                status = suggestionInfo.status,
+                createdAt = suggestionInfo.createdAt,
+            )
+        }
+    }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionEventListener.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionEventListener.kt
@@ -7,17 +7,12 @@ import com.sseudam.suggestion.event.SuggestionUpdateEvent
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
 import com.sseudam.support.extension.logger
-import com.sseudam.trashspot.TrashSpotService
-import com.sseudam.trashspot.image.TrashSpotImage
-import com.sseudam.trashspot.image.TrashSpotImageService
 import com.sseudam.user.UserService
 import org.springframework.modulith.events.ApplicationModuleListener
 import org.springframework.stereotype.Component
 
 @Component
 class SuggestionEventListener(
-    private val trashSpotService: TrashSpotService,
-    private val trashSpotImageService: TrashSpotImageService,
     private val userService: UserService,
     private val fcmSender: FcmSender,
 ) {
@@ -26,40 +21,27 @@ class SuggestionEventListener(
     }
 
     @ApplicationModuleListener
-    fun createSuggestionListener(event: SuggestionUpdateEvent) {
-        if (event.suggestion.status != SuggestionStatus.APPROVE) return
-        val trashSpot = trashSpotService.createTrashSpotBySuggestion(event.suggestion)
-        trashSpotImageService.append(
-            TrashSpotImage.Create(
-                trashSpot.id,
-                event.suggestion.imageUrl,
-            ),
-        )
-    }
-
-    @ApplicationModuleListener
     fun suggestionUpdateNotificationListener(event: SuggestionUpdateEvent) {
         try {
-            val userId = event.suggestion.userId
-            val type = "SUGGESTION"
-            val targetId = event.suggestion.id
+            val suggestion = event.suggestion
             val body =
-                when (event.suggestion.status) {
+                when (suggestion.status) {
                     SuggestionStatus.APPROVE -> NotificationMessages.APPROVE_SUGGESTION_CONTENTS
                     SuggestionStatus.REJECT -> NotificationMessages.REJECT_SUGGESTION_CONTENTS
                     else -> throw ErrorException(ErrorType.INVALID_UPDATE_SUGGESTION_STATUS)
                 }
-            val userProfile = userService.getProfile(userId) ?: throw ErrorException(ErrorType.NOT_FOUND_USER)
+            val userProfile =
+                userService.getProfile(suggestion.userId)
+                    ?: throw ErrorException(ErrorType.NOT_FOUND_USER)
 
             fcmSender.send(
-                sendNotificationMessage =
-                    SendNotificationMessage(
-                        userId = userId,
-                        title = NotificationMessages.DEFAULT_TITLE,
-                        body = userProfile.nickname + body,
-                    ),
-                type = type,
-                parameterValue = targetId.toString(),
+                SendNotificationMessage(
+                    userId = suggestion.userId,
+                    title = NotificationMessages.DEFAULT_TITLE,
+                    body = userProfile.nickname + body,
+                ),
+                type = "SUGGESTION",
+                parameterValue = suggestion.id.toString(),
             )
         } catch (e: Exception) {
             log.warn(e) { "Failed to send notification for user ${event.suggestion.userId}" }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -4,7 +4,6 @@ import com.sseudam.common.ImageS3Caller
 import com.sseudam.common.S3ImageUrl
 import com.sseudam.pet.PetPointAction
 import com.sseudam.pet.event.PetEventPublisher
-import com.sseudam.suggestion.event.SuggestionEventPublisher
 import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
@@ -19,10 +18,8 @@ import org.springframework.stereotype.Service
 class SuggestionService(
     private val suggestionAppender: SuggestionAppender,
     private val suggestionReader: SuggestionReader,
-    private val suggestionUpdater: SuggestionUpdater,
-    private val suggestionDeleter: SuggestionDeleter,
     private val suggestionValidator: SuggestionValidator,
-    private val suggestionEventPublisher: SuggestionEventPublisher,
+    private val suggestionUpdater: SuggestionUpdater,
     private val txAdvice: TxAdvice,
     private val petEventPublisher: PetEventPublisher,
     private val imageS3Caller: ImageS3Caller,
@@ -57,19 +54,10 @@ class SuggestionService(
 
     fun findSpotSuggestionById(suggestionId: Long): SpotSuggestion.Info = suggestionReader.readBy(suggestionId)
 
-    fun updateSuggestion(
+    fun updateStatus(
         suggestionId: Long,
         status: SuggestionStatus,
-    ): SpotSuggestion.Info =
-        txAdvice.write {
-            val suggestion = suggestionUpdater.update(suggestionId, status)
-            suggestionEventPublisher.publish(suggestion)
-            if (suggestion.status == SuggestionStatus.APPROVE) {
-                suggestionDeleter.deleteBy(suggestionId)
-                petEventPublisher.publish(suggestion.userId, PetPointAction.SUGGESTION_APPROVED)
-            }
-            return@write suggestion
-        }
+    ): SpotSuggestion.Info = suggestionUpdater.update(suggestionId, status)
 
     fun validateSpotSuggestionName(name: String) {
         if (suggestionReader.existsByName(name)) {

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
@@ -1,6 +1,8 @@
 package com.sseudam.trashspot
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.sseudam.suggestion.SuggestionService
+import com.sseudam.support.Cache
 import com.sseudam.support.geo.Region
 import com.sseudam.trashspot.image.TrashSpotImageService
 import com.sseudam.user.UserService
@@ -24,12 +26,17 @@ class TrashSpotFacade(
         return trashSpots
     }
 
-    fun findDetails(spotId: Long): TrashSpotDetail {
-        val spot = trashSpotService.findBy(spotId)
-        val image = trashSpotImageService.findBySpotId(spotId).lastOrNull()
-        val suggestioner = suggestionService.findSpotSuggestionBySite(spot.address.site)
-        val user = suggestioner?.let { userService.getProfile(it.userId) }
-        val visitedCount = visitedService.countBySpotId(spotId)
-        return TrashSpotDetail(spot, image, user, visitedCount)
-    }
+    fun findDetails(spotId: Long): TrashSpotDetail =
+        Cache.cache(
+            ttl = 10L,
+            key = "spot:detail:$spotId",
+            typeReference = object : TypeReference<TrashSpotDetail>() {},
+        ) {
+            val spot = trashSpotService.findBy(spotId)
+            val image = trashSpotImageService.findBySpotId(spotId).lastOrNull()
+            val suggestioner = suggestionService.findSpotSuggestionBySite(spot.address.site)
+            val user = suggestioner?.let { userService.getProfile(it.userId) }
+            val visitedCount = visitedService.countBySpotId(spotId)
+            return@cache TrashSpotDetail(spot, image, user, visitedCount)
+        }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #184 

## 📌 작업 내용 및 특이 사항

- 9c6b241d00e5d3960fb2a38f620ff1abf866e8e9: 제보 및 신고 시 내역 삭제 로직 제거 및 로직 리팩토링

## 📝 참고

**왜 제보 승인 시 비동기 이벤트 로직을 동기식으로 변경하였는가?**
- 제보 승인된 spotId를 얻기 위함도 있지만, 내부 txAdvice.writable로 영속화 된 이후 TransacationalEventListener가 뒤늦게 영속화 되기에 장소 저장 컨텍스트를 Facade 레이어에서 처리

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Performance
  - Faster spot detail loading with short-term caching; cache is automatically cleared after approvals or reports to ensure fresh data.

- Improvements
  - Streamlined suggestion status updates, with more reliable notifications to users.
  - Approved suggestions now consistently reflect newly created spots and associated images.

- API Changes
  - Suggestion status update now returns an enhanced result that includes the linked spot ID and full suggestion details (affects admin-facing responses only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->