### PR TITLE
[Fix] Attendance 5 continuity condition

### DIFF
--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/attendance/AttendanceService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/attendance/AttendanceService.kt
@@ -11,14 +11,11 @@ class AttendanceService(
     fun attendance(userId: Long): Triple<Boolean, Attendance.Complete, Boolean> {
         val currentDate = LocalDate.now()
         val attendance = attendanceReader.readLastByUser(userId)
-        println("attendacne: $attendance $currentDate")
         val isFirstAttendanceToday = attendance?.date == currentDate
-
-        println("isFirstAttendanceToday: $isFirstAttendanceToday")
 
         if (attendance == null || !isFirstAttendanceToday) {
             val continuity =
-                if (attendance?.date?.plusDays(1) == currentDate) {
+                if (attendance?.date?.plusDays(1) == currentDate && (attendance?.continuity ?: 0) < 5) {
                     ((attendance?.continuity ?: 0) + 1).coerceAtMost(5)
                 } else {
                     1


### PR DESCRIPTION
## 🌱 관련 이슈
- close #186 

## 📌 작업 내용 및 특이 사항

- 9e556930e3b4eed47df41b2efdb97b8ee6bd2a0d: 연속 출석 6일째 시 1일로 초기화

## 📝 참고

- 출력문 제거

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Attendance streaks now progress only with true day-to-day check-ins; missing a day resets the streak to 1 for accuracy.
  - Streaks are capped at 5 days. After reaching 5, the following day restarts the streak at 1 (if attended), ensuring consistent rewards/visuals tied to streaks.
  - Users may notice corrected streak counts reflecting these rules, improving reliability of attendance tracking and preventing overcounted streaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->