### PR TITLE
[Fix] Remove refreshToken data class

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -3,7 +3,6 @@ package com.sseudam.admin.application
 import com.sseudam.admin.domain.AdminToken
 import com.sseudam.admin.domain.AdminUserProfile
 import com.sseudam.auth.AuthenticationService
-import com.sseudam.auth.token.RefreshToken
 import com.sseudam.notification.FcmSender
 import com.sseudam.notification.NewFirebaseCloudMessage
 import com.sseudam.notification.NotificationService
@@ -60,7 +59,7 @@ class AdminFacade(
 
     fun logout(accessToken: String) = authService.adminLogout(accessToken)
 
-    fun reissue(refreshToken: RefreshToken): AdminToken {
+    fun reissue(refreshToken: String): AdminToken {
         val token = authService.adminReissue(refreshToken)
         return AdminToken(token.accessToken, token.refreshToken)
     }

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/request/AdminRefreshTokenRequest.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/request/AdminRefreshTokenRequest.kt
@@ -1,15 +1,9 @@
 package com.sseudam.admin.presentation.request
 
-import com.sseudam.auth.token.RefreshToken
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "어드민 리프레시 토큰 요청 Json")
 data class AdminRefreshTokenRequest(
     @Schema(description = "리프레시 토큰", example = "refresh_token")
     val refreshToken: String,
-) {
-    fun toRefreshToken(): RefreshToken =
-        RefreshToken(
-            token = refreshToken,
-        )
-}
+)

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/v1/admin/AdminController.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/v1/admin/AdminController.kt
@@ -42,7 +42,7 @@ class AdminController(
     fun reissueToken(
         @RequestBody request: AdminRefreshTokenRequest,
     ): AdminTokenResponse {
-        val token = adminFacade.reissue(request.toRefreshToken())
+        val token = adminFacade.reissue(request.refreshToken)
         return AdminTokenResponse.of(token)
     }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/AuthController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/AuthController.kt
@@ -142,7 +142,7 @@ class AuthController(
     fun reissueToken(
         @RequestBody request: RefreshTokenRequest,
     ): TokenResponse {
-        val token = authenticationService.renew(request.toRefreshToken())
+        val token = authenticationService.renew(request.refreshToken)
         return TokenResponse.toResponse(false, token)
     }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/RefreshTokenRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/RefreshTokenRequest.kt
@@ -1,15 +1,9 @@
 package com.sseudam.presentation.v1.auth.request
 
-import com.sseudam.auth.token.RefreshToken
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "리프레시 토큰 요청")
 data class RefreshTokenRequest(
     @Schema(description = "리프레시 토큰", example = "refresh_token")
     val refreshToken: String,
-) {
-    fun toRefreshToken(): RefreshToken =
-        RefreshToken(
-            token = refreshToken,
-        )
-}
+)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationService.kt
@@ -1,6 +1,5 @@
 package com.sseudam.auth
 
-import com.sseudam.auth.token.RefreshToken
 import com.sseudam.auth.token.Token
 import com.sseudam.user.SocialUser
 import com.sseudam.user.User
@@ -30,7 +29,7 @@ class AuthenticationService(
             socialUser = socialUser,
         )
 
-    fun renew(refreshToken: RefreshToken): Token = authenticationProcessor.renew(refreshToken.token)
+    fun renew(refreshToken: String): Token = authenticationProcessor.renew(refreshToken)
 
     fun logout(token: String): String = authenticationProcessor.remove(token)
 
@@ -40,7 +39,7 @@ class AuthenticationService(
 
     fun adminLogin(adminId: Long): Token = authenticationProcessor.adminLogin(adminId, listOf(GrantedAuthority(AuthorityType.ADMIN)))
 
-    fun adminReissue(refreshToken: RefreshToken): Token = authenticationProcessor.adminRenew(refreshToken.token)
+    fun adminReissue(refreshToken: String): Token = authenticationProcessor.adminRenew(refreshToken)
 
     fun adminLogout(accessToken: String) = authenticationProcessor.adminLogout(accessToken)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/token/RefreshToken.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/token/RefreshToken.kt
@@ -1,5 +1,0 @@
-package com.sseudam.auth.token
-
-data class RefreshToken(
-    val token: String,
-)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이 사항

- 405222dff6255e3fb04a2981bf4f145dfddbda66: 무의미한 refreshToken 객체 삭제

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined token renewal and admin reissue to use raw refresh token strings end-to-end, removing redundant conversions for a simpler, more consistent flow.

- Compatibility
  - No user-facing changes. Existing endpoints, request bodies, and responses remain the same. No action required for clients.

- Stability
  - Reduced complexity in authentication flows to improve maintainability and reduce potential points of failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->