### PR TITLE
[Fix] After withdrawal, Re-Signup case

### DIFF
--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationFacade.kt
@@ -1,6 +1,7 @@
 package com.sseudam.auth
 
 import com.sseudam.auth.token.Token
+import com.sseudam.pet.UserPetFacade
 import com.sseudam.user.NewUser
 import com.sseudam.user.SocialUser
 import com.sseudam.user.UserService
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service
 @Service
 class AuthenticationFacade(
     private val userService: UserService,
+    private val userPetFacade: UserPetFacade,
     private val authenticationService: AuthenticationService,
 ) {
     fun socialLogin(
@@ -31,6 +33,8 @@ class AuthenticationFacade(
                 deviceId = deviceId,
                 socialUser = socialUser,
             )
+
+        userPetFacade.findPetInfo(socialUser.id)
 
         return isNewUser to token
     }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserFacade.kt
@@ -2,6 +2,7 @@ package com.sseudam.user
 
 import com.sseudam.auth.AuthenticationService
 import com.sseudam.pet.UserPetService
+import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Service
 
 @Service
@@ -9,14 +10,16 @@ class UserFacade(
     private val userService: UserService,
     private val authenticationService: AuthenticationService,
     private val userPetService: UserPetService,
+    private val txAdvice: TxAdvice,
 ) {
-    fun withdrawalUser(user: User) {
-        userPetService.deleteByUser(user.id)
-        userService.deleteUser(
-            NewUserWithdrawal(
-                user = user,
-            ),
-        )
-        authenticationService.withdrawUser(user.key)
-    }
+    fun withdrawalUser(user: User) =
+        txAdvice.write {
+            userPetService.deleteByUser(user.id)
+            userService.deleteUser(
+                NewUserWithdrawal(
+                    user = user,
+                ),
+            )
+            authenticationService.withdrawUser(user.key)
+        }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
@@ -8,6 +8,7 @@ import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
 import com.sseudam.support.page.Page
+import com.sseudam.support.tx.TxAdvice
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -20,18 +21,20 @@ class UserService(
     private val userValidator: UserValidator,
     private val userPetAppender: UserPetAppender,
     private val petReader: PetReader,
+    private val txAdvice: TxAdvice,
 ) {
-    fun create(newUser: NewUser): User {
-        userValidator.verifyEmail(newUser.email)
-        val (currentYear, currentMonth) = LocalDate.now().let { it.year to it.month }
-        val pets = petReader.readAllLatestSeasonPets(currentYear, currentMonth)
-        val level1Pet =
-            pets.find { it.levelType == Pet.LevelType.LEVEL_1 }
-                ?: throw ErrorException(ErrorType.INVALID_PET_LEVEL_TYPE)
-        val createUser = userAppender.create(newUser)
-        userPetAppender.append(createUser.id, level1Pet)
-        return createUser
-    }
+    fun create(newUser: NewUser): User =
+        txAdvice.write {
+            userValidator.verifyEmail(newUser.email)
+            val (currentYear, currentMonth) = LocalDate.now().let { it.year to it.month }
+            val pets = petReader.readAllLatestSeasonPets(currentYear, currentMonth)
+            val level1Pet =
+                pets.find { it.levelType == Pet.LevelType.LEVEL_1 }
+                    ?: throw ErrorException(ErrorType.INVALID_PET_LEVEL_TYPE)
+            val createUser = userAppender.create(newUser)
+            userPetAppender.append(createUser.id, level1Pet)
+            return@write createUser
+        }
 
     fun getProfile(userId: Long): UserProfile? = userReader.readUserProfile(userId)
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
@@ -1,9 +1,15 @@
 package com.sseudam.user
 
 import com.sseudam.common.Address
+import com.sseudam.pet.Pet
+import com.sseudam.pet.PetReader
+import com.sseudam.pet.UserPetAppender
 import com.sseudam.support.cursor.OffsetPageRequest
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
 import com.sseudam.support.page.Page
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class UserService(
@@ -12,10 +18,19 @@ class UserService(
     private val userUpdater: UserUpdater,
     private val userDeleter: UserDeleter,
     private val userValidator: UserValidator,
+    private val userPetAppender: UserPetAppender,
+    private val petReader: PetReader,
 ) {
     fun create(newUser: NewUser): User {
         userValidator.verifyEmail(newUser.email)
-        return userAppender.create(newUser)
+        val (currentYear, currentMonth) = LocalDate.now().let { it.year to it.month }
+        val pets = petReader.readAllLatestSeasonPets(currentYear, currentMonth)
+        val level1Pet =
+            pets.find { it.levelType == Pet.LevelType.LEVEL_1 }
+                ?: throw ErrorException(ErrorType.INVALID_PET_LEVEL_TYPE)
+        val createUser = userAppender.create(newUser)
+        userPetAppender.append(createUser.id, level1Pet)
+        return createUser
     }
 
     fun getProfile(userId: Long): UserProfile? = userReader.readUserProfile(userId)

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/pet/UserPetCoreRepository.kt
@@ -103,7 +103,7 @@ class UserPetCoreRepository(
         txAdvice.write {
             val userPet =
                 userPetJpaRepository.findByUserIdAndDeletedAtIsNull(userId)
-                    ?: throw ErrorException(ErrorType.NOT_FOUND_DATA)
-            userPet.softDelete()
+            userPet?.softDelete()
+            return@write
         }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이 사항

- 803c5e005137cc70785f12e55455fcfd3b92e6d0: 탈퇴 후 재가입 로직 수정

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New users automatically receive a Level 1 pet upon account creation; user creation is now performed transactionally for consistency.

- Bug Fixes
  - Account deletion is now transactional, ensuring related data is removed consistently.
  - Social login now initializes/verifies pet info to avoid missing pet data.
  - Improved robustness when removing pet links during user deletion to prevent edge-case failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->