### PR TITLE
[Fix] FindCurrentSeasonPetHistory point locked condition

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/pet/PetController.kt
@@ -58,14 +58,14 @@ class PetController(
     @GetMapping("/pets/season")
     fun findUserPetSeasonInfo(user: User): UserPetLevelHistoryCurrentSeasonAllResponse {
         val seasonHistory = userPetFacade.findCurrentSeasonPetHistory(user.id)
-        val petInfo = petService.findBy(seasonHistory.first.petId)
+        val petInfo = petService.findBy(seasonHistory.userPetInfo.petId)
 
-        val petLevel = userPetPolicy.getLevelType(seasonHistory.first.point)
+        val petLevel = userPetPolicy.getLevelType(seasonHistory.userPetInfo.point)
         val maxLevelStandard = userPetPolicy.getMaxLevelStandard(petLevel)
         val season = userPetPolicy.getSeasonByPetInfo(petInfo)
         return UserPetLevelHistoryCurrentSeasonAllResponse.of(
-            UserPetInfoResponse.of(seasonHistory.first, petLevel, season, maxLevelStandard),
-            seasonHistory.second,
+            UserPetInfoResponse.of(seasonHistory.userPetInfo, petLevel, season, maxLevelStandard),
+            seasonHistory.seasonHistory,
         )
     }
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetCurrentSeasonHistoryResult.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetCurrentSeasonHistoryResult.kt
@@ -1,0 +1,6 @@
+package com.sseudam.pet
+
+data class UserPetCurrentSeasonHistoryResult(
+    val userPetInfo: UserPet.Info,
+    val seasonHistory: List<UserPetLevelUpCurrentSeasonHistoryInfo>,
+)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/pet/UserPetFacade.kt
@@ -27,8 +27,8 @@ class UserPetFacade(
             }
     }
 
-    fun findCurrentSeasonPetHistory(userId: Long): Pair<UserPet.Info, List<UserPetLevelUpCurrentSeasonHistoryInfo>> {
-        val (currentYear, currentMonth) = LocalDate.now().let { it.year to it.month }
+    fun findCurrentSeasonPetHistory(userId: Long): UserPetCurrentSeasonHistoryResult {
+        val (currentYear, currentMonth) = LocalDate.now().run { year to month }
         val pets = petService.findAllLatestSeasonPets(currentYear, currentMonth)
         val userPetInfo =
             userPetService.findByUser(userId)
@@ -38,21 +38,17 @@ class UserPetFacade(
                 ?: throw ErrorException(ErrorType.INVALID_PET_LEVEL_TYPE)
 
         val histories = petLevelUpHistoryService.findAllBy(currentYear, currentMonth, userPetInfo.id)
-        val levelTypeToHistory = histories.groupBy { it.levelType }.mapValues { it.value.maxByOrNull { history -> history.createdAt } }
+        val levelTypeToHistory =
+            histories
+                .groupBy { it.levelType }
+                .mapValues { it.value.maxByOrNull { history -> history.createdAt } }
 
         val petHistoryInfo =
             pets.map { petInfo ->
                 val pointStandard = userPetPolicy.getMinLevelStandard(petInfo.levelType)
                 val history = levelTypeToHistory[petInfo.levelType]
                 val userPetLevelType = userPetPolicy.getLevelType(userPetInfo.point)
-                val isLocked =
-                    if (userPetLevelType == Pet.LevelType.SPECIAL ||
-                        (userPetInfo.point == 0L && userPetLevelType == Pet.LevelType.LEVEL_1)
-                    ) {
-                        false
-                    } else {
-                        userPetInfo.point <= pointStandard
-                    }
+                val isLocked = petInfo.levelType.level > userPetLevelType.level
                 val createdAt = history?.createdAt ?: LocalDateTime.of(currentYear, currentMonth, 1, 0, 0)
 
                 UserPetLevelUpCurrentSeasonHistoryInfo(
@@ -61,12 +57,16 @@ class UserPetFacade(
                     levelType = petInfo.levelType,
                     point = pointStandard,
                     isLocked = isLocked,
-                    season = userPetPolicy.getSeasonByYearMonth(history?.year ?: currentYear, history?.monthly ?: currentMonth),
+                    season =
+                        userPetPolicy.getSeasonByYearMonth(
+                            history?.year ?: currentYear,
+                            history?.monthly ?: currentMonth,
+                        ),
                     createdAt = createdAt,
                 )
             }
 
-        return Pair(userPetInfo, petHistoryInfo)
+        return UserPetCurrentSeasonHistoryResult(userPetInfo, petHistoryInfo)
     }
 
     fun findAllPetHistory(userId: Long): List<UserPetLevelUpHistoryInfo> =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #203 

## 📌 작업 내용 및 특이 사항

- 685ec0a12712185765c5952628e3ad3aa980dd58: point locked condition

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected pet level lock status for the current season to display accurate availability.
  - Improved consistency when showing your pet info and season history.

- Refactor
  - Streamlined season history retrieval into a dedicated response model for clearer, more reliable handling.
  - Simplified related controller logic to reduce edge-case inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->