### PR TITLE
[Fix] Spot name alter table column length

### DIFF
--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
@@ -26,7 +26,7 @@ class SpotReportEntity(
     @Column
     val point: Point,
     val address: Address,
-    @Column(length = 50)
+    @Column(length = 100)
     val spotName: String,
     @Enumerated(value = EnumType.STRING)
     @Column(length = 15)

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
@@ -18,7 +18,7 @@ import org.locationtech.jts.geom.Point
 @Table(name = "t_spot_suggestion")
 class SpotSuggestionEntity(
     val userId: Long,
-    @Column(length = 50)
+    @Column(length = 100)
     val spotName: String,
     @Column
     val point: Point,

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotEntity.kt
@@ -17,7 +17,7 @@ import org.locationtech.jts.geom.Point
 @Entity
 @Table(name = "t_trash_spot")
 class TrashSpotEntity(
-    @Column(length = 50)
+    @Column(length = 100)
     var name: String,
     @Enumerated(value = EnumType.STRING)
     @Column(length = 20)

--- a/sseudam-storage/db-core/src/main/resources/db/migration/V2__alter_table_column_trash_spot_name.sql
+++ b/sseudam-storage/db-core/src/main/resources/db/migration/V2__alter_table_column_trash_spot_name.sql
@@ -1,0 +1,5 @@
+ALTER TABLE t_trash_spot ALTER COLUMN name TYPE VARCHAR(100);
+ALTER TABLE t_spot_suggestion ALTER COLUMN spot_name TYPE VARCHAR(100);
+ALTER TABLE t_spot_report ALTER COLUMN spot_name TYPE VARCHAR(100);
+
+


### PR DESCRIPTION
## 🌱 관련 이슈
- close #208 

## 📌 작업 내용 및 특이 사항

- 389811c82c6ce37285bf6d203f2dccff4483fa2a: spot name length

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased the maximum length for spot names from 50 to 100 characters across trash spots, spot suggestions, and spot reports.
  - Users can now enter longer names in related forms without truncation.
  - Applies to new entries and existing records; data remains intact.
  - The update is applied automatically during upgrade, with no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->