### PR TITLE
[Feature] Admin suggestion reject reason

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -18,6 +18,7 @@ import com.sseudam.report.UpdateReport
 import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SuggestionService
 import com.sseudam.suggestion.SuggestionStatus
+import com.sseudam.suggestion.UpdateSuggestionCommand
 import com.sseudam.suggestion.event.SuggestionEventPublisher
 import com.sseudam.support.CacheRepository
 import com.sseudam.support.cursor.OffsetPageRequest
@@ -97,9 +98,9 @@ class AdminFacade(
     fun findSuggestions(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
-    ): Page<SpotSuggestion.Info> = suggestionService.findSuggestionsBy(offsetPageRequest, searchStatus)
+    ): Page<SpotSuggestion.Detail> = suggestionService.findSuggestionsBy(offsetPageRequest, searchStatus)
 
-    fun findSuggestionDetails(suggestionId: Long): SpotSuggestion.Info = suggestionService.findSpotSuggestionById(suggestionId)
+    fun findSuggestionDetails(suggestionId: Long): SpotSuggestion.Detail = suggestionService.findSpotSuggestionById(suggestionId)
 
     fun findReports(
         offsetPageRequest: OffsetPageRequest,
@@ -108,25 +109,28 @@ class AdminFacade(
 
     fun findReportDetails(reportId: Long): SpotReport.Detail = reportFacade.findReportDetails(reportId)
 
-    fun updateSpotSuggestionStatus(
-        suggestionId: Long,
-        status: SuggestionStatus,
-    ): SpotSuggestion.UpdateResult =
+    fun updateSpotSuggestionStatus(command: UpdateSuggestionCommand): SpotSuggestion.UpdateResult =
         txAdvice.write {
-            val suggestion = suggestionService.updateStatus(suggestionId, status)
+            val suggestion = suggestionService.updateStatus(command.suggestionId, command.status)
             val spotId: Long =
-                if (suggestion.status == SuggestionStatus.APPROVE) {
-                    val trashSpot = trashSpotService.createTrashSpotBySuggestion(suggestion)
-                    trashSpotImageService.append(
-                        TrashSpotImage.Create(trashSpot.id, suggestion.imageUrl),
-                    )
-                    petEventPublisher.publish(suggestion.userId, PetPointAction.SUGGESTION_APPROVED)
-                    cacheRepository.delete(SPOT_DETAIL_CACHE_KEY_PREFIX + trashSpot.id)
-                    trashSpot.id
-                } else {
-                    0L
+                when (suggestion.status) {
+                    SuggestionStatus.APPROVE -> {
+                        val trashSpot = trashSpotService.createTrashSpotBySuggestion(suggestion)
+                        trashSpotImageService.append(
+                            TrashSpotImage.Create(trashSpot.id, suggestion.imageUrl),
+                        )
+                        petEventPublisher.publish(suggestion.userId, PetPointAction.SUGGESTION_APPROVED)
+                        cacheRepository.delete(SPOT_DETAIL_CACHE_KEY_PREFIX + trashSpot.id)
+                        trashSpot.id
+                    }
+                    SuggestionStatus.REJECT -> {
+                        suggestionService.appendReject(command.suggestionId, command.reason)
+                        0L
+                    }
+                    else -> {
+                        0L
+                    }
                 }
-
             suggestionEventPublisher.publish(suggestion)
             return@write SpotSuggestion.UpdateResult.of(suggestion, spotId)
         }

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/request/suggestion/AdminUpdateSuggestionRequest.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/request/suggestion/AdminUpdateSuggestionRequest.kt
@@ -1,0 +1,16 @@
+package com.sseudam.admin.presentation.request.suggestion
+
+import com.sseudam.suggestion.SuggestionStatus
+import com.sseudam.suggestion.UpdateSuggestionCommand
+
+data class AdminUpdateSuggestionRequest(
+    val reason: String?,
+    val status: SuggestionStatus,
+) {
+    fun toCommand(suggestionId: Long) =
+        UpdateSuggestionCommand(
+            suggestionId = suggestionId,
+            reason = reason,
+            status = status,
+        )
+}

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAdminResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAdminResponse.kt
@@ -27,11 +27,13 @@ data class SpotSuggestionAdminResponse(
     val imageUrl: String,
     @Schema(description = "제보 상태")
     val status: SuggestionStatus,
+    @Schema(description = "거절 사유")
+    val rejectReason: String? = null,
     @Schema(description = "제보 시간")
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun of(suggestion: SpotSuggestion.Info) =
+        fun of(suggestion: SpotSuggestion.Detail) =
             SpotSuggestionAdminResponse(
                 id = suggestion.id,
                 point = suggestion.point,
@@ -41,6 +43,7 @@ data class SpotSuggestionAdminResponse(
                 trashType = suggestion.trashType,
                 imageUrl = suggestion.imageUrl,
                 status = suggestion.status,
+                rejectReason = suggestion.rejectReason,
                 createdAt = suggestion.createdAt,
             )
     }

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAllAdminResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAllAdminResponse.kt
@@ -8,7 +8,7 @@ data class SpotSuggestionAllAdminResponse(
     val totalCount: Long,
 ) {
     companion object {
-        fun of(page: Page<SpotSuggestion.Info>) =
+        fun of(page: Page<SpotSuggestion.Detail>) =
             SpotSuggestionAllAdminResponse(
                 list = page.content.map { SpotSuggestionAdminResponse.of(it) },
                 totalCount = page.totalCount,

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/v1/suggestion/AdminSuggestionController.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/v1/suggestion/AdminSuggestionController.kt
@@ -1,6 +1,7 @@
 package com.sseudam.admin.presentation.v1.suggestion
 
 import com.sseudam.admin.application.AdminFacade
+import com.sseudam.admin.presentation.request.suggestion.AdminUpdateSuggestionRequest
 import com.sseudam.admin.presentation.response.suggestion.SpotSuggestionAdminResponse
 import com.sseudam.admin.presentation.response.suggestion.SpotSuggestionAllAdminResponse
 import com.sseudam.admin.presentation.v1.annotation.AdminTagDocs
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 
 @AdminTagDocs
@@ -41,5 +43,6 @@ class AdminSuggestionController(
     fun updateSuggestionStatus(
         @PathVariable suggestionId: Long,
         @RequestParam status: SuggestionStatus,
-    ) = adminFacade.updateSpotSuggestionStatus(suggestionId, status)
+        @RequestBody request: AdminUpdateSuggestionRequest,
+    ) = adminFacade.updateSpotSuggestionStatus(request.toCommand(suggestionId))
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationFacade.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/AuthenticationFacade.kt
@@ -1,7 +1,6 @@
 package com.sseudam.auth
 
 import com.sseudam.auth.token.Token
-import com.sseudam.pet.UserPetFacade
 import com.sseudam.user.NewUser
 import com.sseudam.user.SocialUser
 import com.sseudam.user.UserService
@@ -10,7 +9,6 @@ import org.springframework.stereotype.Service
 @Service
 class AuthenticationFacade(
     private val userService: UserService,
-    private val userPetFacade: UserPetFacade,
     private val authenticationService: AuthenticationService,
 ) {
     fun socialLogin(

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReport.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReport.kt
@@ -62,7 +62,7 @@ class SpotReport {
         val createdAt: LocalDateTime,
     )
 
-    /** SpotReport Info
+    /** SpotReport Detail
      * @property id 쓰레기통 신고 id
      * @property spotId 쓰레기통 위치 id
      * @property userId 신고자 id
@@ -74,7 +74,7 @@ class SpotReport {
      * @property trashType 쓰레기통 타입
      * @property imageUrl 신고된 S3 imageUrl
      * @property status 신고 상태
-     * @property rejectReason 신고 사유
+     * @property rejectReason 거절 사유
      * @property createdAt 신고 시간
      */
     data class Detail(

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestion.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestion.kt
@@ -3,6 +3,7 @@ package com.sseudam.suggestion
 import com.sseudam.common.Address
 import com.sseudam.common.GeoJson
 import com.sseudam.common.Region
+import com.sseudam.suggestion.reject.SuggestionReject
 import com.sseudam.trashspot.TrashType
 import java.time.LocalDateTime
 
@@ -54,6 +55,52 @@ class SpotSuggestion {
         val status: SuggestionStatus = SuggestionStatus.WAITING,
         val createdAt: LocalDateTime,
     )
+
+    /** SpotSuggestion Detail
+     * @property id 제보 id
+     * @property userId 제보자 id
+     * @property spotName 쓰레기통 이름
+     * @property point 제보 위치
+     * @property region 제보 지역
+     * @property address 제보 주소
+     * @property trashType 제보된 쓰레기통 타입
+     * @property status 제보 상태
+     * @property imageUrl 제보된 S3 imageUrl
+     * @property rejectReason 거절 사유
+     * @property createdAt 제보 시간
+     */
+    data class Detail(
+        val id: Long,
+        val userId: Long,
+        val spotName: String,
+        val point: GeoJson,
+        val region: Region,
+        val address: Address,
+        val trashType: TrashType,
+        val imageUrl: String,
+        val status: SuggestionStatus = SuggestionStatus.WAITING,
+        val rejectReason: String?,
+        val createdAt: LocalDateTime,
+    ) {
+        companion object {
+            fun of(
+                suggestionInfo: Info,
+                reject: SuggestionReject.Info?,
+            ) = Detail(
+                id = suggestionInfo.id,
+                userId = suggestionInfo.userId,
+                spotName = suggestionInfo.spotName,
+                point = suggestionInfo.point,
+                region = suggestionInfo.region,
+                address = suggestionInfo.address,
+                trashType = suggestionInfo.trashType,
+                imageUrl = suggestionInfo.imageUrl,
+                status = suggestionInfo.status,
+                rejectReason = reject?.reason,
+                createdAt = suggestionInfo.createdAt,
+            )
+        }
+    }
 
     data class UpdateResult(
         val id: Long,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestionRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SpotSuggestionRepository.kt
@@ -22,7 +22,7 @@ interface SpotSuggestionRepository {
     fun findAllBy(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
-    ): Page<SpotSuggestion.Info>
+    ): Page<SpotSuggestion.Detail>
 
     fun update(
         suggestionId: Long,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionAppender.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionAppender.kt
@@ -1,5 +1,7 @@
 package com.sseudam.suggestion
 
+import com.sseudam.suggestion.reject.SuggestionReject
+import com.sseudam.suggestion.reject.SuggestionRejectRepository
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.PrecisionModel
@@ -8,6 +10,7 @@ import org.springframework.stereotype.Component
 @Component
 class SuggestionAppender(
     private val spotSuggestionRepository: SpotSuggestionRepository,
+    private val suggestionRejectRepository: SuggestionRejectRepository,
 ) {
     companion object {
         private val GEOMETRY_FACTORY = GeometryFactory(PrecisionModel(), 4326)
@@ -22,5 +25,12 @@ class SuggestionAppender(
                 Coordinate(createSpotSuggestion.longitude, createSpotSuggestion.latitude),
             )
         return spotSuggestionRepository.create(imageUrl, point, createSpotSuggestion)
+    }
+
+    fun appendReject(
+        suggestionId: Long,
+        reason: String?,
+    ) {
+        suggestionRejectRepository.save(SuggestionReject.Create(suggestionId, reason ?: ""))
     }
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionReader.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionReader.kt
@@ -1,5 +1,7 @@
 package com.sseudam.suggestion
 
+import com.sseudam.suggestion.reject.SuggestionReject
+import com.sseudam.suggestion.reject.SuggestionRejectRepository
 import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.page.Page
 import org.locationtech.jts.geom.Point
@@ -8,6 +10,7 @@ import org.springframework.stereotype.Component
 @Component
 class SuggestionReader(
     private val spotSuggestionRepository: SpotSuggestionRepository,
+    private val suggestionRejectRepository: SuggestionRejectRepository,
 ) {
     fun readBy(suggestionId: Long): SpotSuggestion.Info = spotSuggestionRepository.findBy(suggestionId)
 
@@ -18,9 +21,11 @@ class SuggestionReader(
     fun readAllBy(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
-    ): Page<SpotSuggestion.Info> = spotSuggestionRepository.findAllBy(offsetPageRequest, searchStatus)
+    ): Page<SpotSuggestion.Detail> = spotSuggestionRepository.findAllBy(offsetPageRequest, searchStatus)
 
     fun existsByName(name: String): Boolean = spotSuggestionRepository.existsByName(name)
 
     fun readByPoint(point: Point): SpotSuggestion.Info? = spotSuggestionRepository.findByPoint(point)
+
+    fun findRejectBySuggestionId(suggestionId: Long): SuggestionReject.Info? = suggestionRejectRepository.findBySuggestionId(suggestionId)
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -44,6 +44,11 @@ class SuggestionService(
             return@write spotSuggestion to uploadUrl
         }
 
+    fun appendReject(
+        suggestionId: Long,
+        reason: String?,
+    ) = suggestionAppender.appendReject(suggestionId, reason)
+
     fun findAllSpotSuggestionByUser(userId: Long): List<SpotSuggestion.Info> = suggestionReader.readAllByUser(userId)
 
     fun findSpotSuggestionBySite(site: String): SpotSuggestion.Info? = suggestionReader.readBySite(site)
@@ -53,9 +58,13 @@ class SuggestionService(
     fun findSuggestionsBy(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
-    ): Page<SpotSuggestion.Info> = suggestionReader.readAllBy(offsetPageRequest, searchStatus)
+    ): Page<SpotSuggestion.Detail> = suggestionReader.readAllBy(offsetPageRequest, searchStatus)
 
-    fun findSpotSuggestionById(suggestionId: Long): SpotSuggestion.Info = suggestionReader.readBy(suggestionId)
+    fun findSpotSuggestionById(suggestionId: Long): SpotSuggestion.Detail {
+        val suggestion = suggestionReader.readBy(suggestionId)
+        val rejectSuggestion = suggestionReader.findRejectBySuggestionId(suggestionId)
+        return SpotSuggestion.Detail.of(suggestion, rejectSuggestion)
+    }
 
     fun updateStatus(
         suggestionId: Long,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/UpdateSuggestionCommand.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/UpdateSuggestionCommand.kt
@@ -1,0 +1,7 @@
+package com.sseudam.suggestion
+
+data class UpdateSuggestionCommand(
+    val suggestionId: Long,
+    val status: SuggestionStatus,
+    val reason: String?,
+)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/reject/SuggestionReject.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/reject/SuggestionReject.kt
@@ -1,0 +1,16 @@
+package com.sseudam.suggestion.reject
+
+import java.time.LocalDateTime
+
+class SuggestionReject {
+    data class Create(
+        val suggestionId: Long,
+        val reason: String,
+    )
+
+    data class Info(
+        val suggestionId: Long,
+        val reason: String?,
+        val createdAt: LocalDateTime,
+    )
+}

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/reject/SuggestionRejectRepository.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/reject/SuggestionRejectRepository.kt
@@ -1,0 +1,7 @@
+package com.sseudam.suggestion.reject
+
+interface SuggestionRejectRepository {
+    fun save(create: SuggestionReject.Create): SuggestionReject.Info
+
+    fun findBySuggestionId(suggestionId: Long): SuggestionReject.Info?
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
@@ -60,7 +60,7 @@ class SpotSuggestionCoreRepository(
     override fun findAllBy(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
-    ): Page<SpotSuggestion.Info> =
+    ): Page<SpotSuggestion.Detail> =
         txAdvice.readOnly {
             spotSuggestionCustomRepository.findAllBy(offsetPageRequest, searchStatus)
         }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCustomRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCustomRepository.kt
@@ -1,5 +1,7 @@
 package com.sseudam.storage.db.core.suggestion
 
+import com.sseudam.storage.db.core.suggestion.model.SpotSuggestionEntityWithReject
+import com.sseudam.storage.db.core.suggestion.reject.SuggestionRejectEntity
 import com.sseudam.storage.db.core.support.JDSLExtensions
 import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SuggestionStatus
@@ -16,7 +18,7 @@ class SpotSuggestionCustomRepository(
     fun findAllBy(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
-    ): Page<SpotSuggestion.Info> {
+    ): Page<SpotSuggestion.Detail> {
         val pageable =
             PageRequest.of(
                 offsetPageRequest.page,
@@ -26,18 +28,33 @@ class SpotSuggestionCustomRepository(
 
         val suggestions =
             spotSuggestionJpaRepository.findPage(JDSLExtensions, pageable) {
-                select(entity(SpotSuggestionEntity::class))
-                    .from(entity(SpotSuggestionEntity::class))
-                    .whereAnd(
-//                        path(SpotSuggestionEntity::deletedAt).isNull(),
-                        searchStatus?.let {
-                            path(SpotSuggestionEntity::status).eq(it)
-                        },
-                    )
+                selectNew<SpotSuggestionEntityWithReject>(
+                    entity(SpotSuggestionEntity::class),
+                    entity(SuggestionRejectEntity::class).path(SuggestionRejectEntity::reason),
+                ).from(
+                    entity(SpotSuggestionEntity::class),
+                    leftJoin(SuggestionRejectEntity::class).on(
+                        path(SpotSuggestionEntity::id)
+                            .eq(path(SuggestionRejectEntity::suggestionId)),
+                    ),
+                ).whereAnd(
+                    searchStatus?.let {
+                        path(SpotSuggestionEntity::status).eq(it)
+                    },
+                ).orderBy(
+                    path(SpotSuggestionEntity::createdAt).desc(),
+                )
             }
 
         return Page.of(
-            content = suggestions.content.mapNotNull { it?.toSpotSuggestion() },
+            content =
+                suggestions.content.mapNotNull { result ->
+                    result?.let {
+                        SpotSuggestion.Detail
+                            .of(it.entity.toSpotSuggestion(), null)
+                            .copy(rejectReason = it.rejectReason)
+                    }
+                },
             totalCount = suggestions.totalElements,
         )
     }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/model/SpotSuggestionEntityWithReject.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/model/SpotSuggestionEntityWithReject.kt
@@ -1,0 +1,8 @@
+package com.sseudam.storage.db.core.suggestion.model
+
+import com.sseudam.storage.db.core.suggestion.SpotSuggestionEntity
+
+data class SpotSuggestionEntityWithReject(
+    val entity: SpotSuggestionEntity,
+    val rejectReason: String?,
+)

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/reject/SuggestionRejectCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/reject/SuggestionRejectCoreRepository.kt
@@ -1,0 +1,20 @@
+package com.sseudam.storage.db.core.suggestion.reject
+
+import com.sseudam.suggestion.reject.SuggestionReject
+import com.sseudam.suggestion.reject.SuggestionRejectRepository
+import com.sseudam.support.tx.TxAdvice
+import org.springframework.stereotype.Repository
+
+@Repository
+class SuggestionRejectCoreRepository(
+    private val suggestionRejectJpaRepository: SuggestionRejectJpaRepository,
+    private val txAdvice: TxAdvice,
+) : SuggestionRejectRepository {
+    override fun save(create: SuggestionReject.Create): SuggestionReject.Info =
+        suggestionRejectJpaRepository.save(SuggestionRejectEntity(create)).toSuggestionReject()
+
+    override fun findBySuggestionId(suggestionId: Long): SuggestionReject.Info? =
+        txAdvice.readOnly {
+            suggestionRejectJpaRepository.findBySuggestionId(suggestionId)?.toSuggestionReject()
+        }
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/reject/SuggestionRejectEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/reject/SuggestionRejectEntity.kt
@@ -1,0 +1,27 @@
+package com.sseudam.storage.db.core.suggestion.reject
+
+import com.sseudam.storage.db.core.support.BaseEntity
+import com.sseudam.suggestion.reject.SuggestionReject
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "t_reject_suggestion")
+class SuggestionRejectEntity(
+    val suggestionId: Long,
+    val reason: String?,
+) : BaseEntity() {
+    constructor(
+        create: SuggestionReject.Create,
+    ) : this (
+        suggestionId = create.suggestionId,
+        reason = create.reason,
+    )
+
+    fun toSuggestionReject(): SuggestionReject.Info =
+        SuggestionReject.Info(
+            suggestionId = suggestionId,
+            reason = reason,
+            createdAt = createdAt,
+        )
+}

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/reject/SuggestionRejectJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/reject/SuggestionRejectJpaRepository.kt
@@ -1,0 +1,10 @@
+package com.sseudam.storage.db.core.suggestion.reject
+
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SuggestionRejectJpaRepository :
+    JpaRepository<SuggestionRejectEntity, Long>,
+    KotlinJdslJpqlExecutor {
+    fun findBySuggestionId(suggestionId: Long): SuggestionRejectEntity?
+}

--- a/sseudam-storage/db-core/src/main/resources/db/migration/V0__init.sql
+++ b/sseudam-storage/db-core/src/main/resources/db/migration/V0__init.sql
@@ -149,16 +149,6 @@ CREATE TABLE t_reject_report (
     deleted_at TIMESTAMP
 );
 
--- 제보 거절 테이블
-CREATE TABLE t_reject_suggestion (
-    id BIGSERIAL PRIMARY KEY,
-    suggestion_id BIGINT NOT NULL,
-    reason TEXT,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP
-);
-
 -- 쓰레기통 제안 테이블
 CREATE TABLE t_spot_suggestion (
     id BIGSERIAL PRIMARY KEY,

--- a/sseudam-storage/db-core/src/main/resources/db/migration/V0__init.sql
+++ b/sseudam-storage/db-core/src/main/resources/db/migration/V0__init.sql
@@ -21,6 +21,16 @@ CREATE TABLE event_publication (
     CONSTRAINT event_publication_pkey PRIMARY KEY (id)
 );
 
+CREATE TABLE public.event_publication_archive (
+    id uuid NOT NULL,
+    completion_date timestamptz(6) NULL,
+    event_type varchar(255) NULL,
+    listener_id varchar(255) NULL,
+    publication_date timestamptz(6) NULL,
+    serialized_event text NULL,
+    CONSTRAINT event_publication_archive_pkey PRIMARY KEY (id)
+);
+
 -- ================================
 -- 사용자 관련 테이블
 -- ================================
@@ -133,6 +143,16 @@ CREATE TABLE t_spot_report (
 CREATE TABLE t_reject_report (
     id BIGSERIAL PRIMARY KEY,
     report_id BIGINT NOT NULL,
+    reason TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP
+);
+
+-- 제보 거절 테이블
+CREATE TABLE t_reject_suggestion (
+    id BIGSERIAL PRIMARY KEY,
+    suggestion_id BIGINT NOT NULL,
     reason TEXT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP,

--- a/sseudam-storage/db-core/src/main/resources/db/migration/V3__create_reject_suggestion_table.sql
+++ b/sseudam-storage/db-core/src/main/resources/db/migration/V3__create_reject_suggestion_table.sql
@@ -1,0 +1,9 @@
+-- 제보 거절 테이블
+CREATE TABLE t_reject_suggestion (
+    id BIGSERIAL PRIMARY KEY,
+    suggestion_id BIGINT NOT NULL,
+    reason TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP
+);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #215 

## 📌 작업 내용 및 특이 사항

- d6fbc99fc6ea44bc894921c4428cf76684f1f175: 제보 반려 사유 저장
- 70b986e522b13009fd633f83a4faaad27dda4a6a: t_reject_suggestion flyway sql

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admins can now reject spot suggestions with an optional reason.
  - Suggestion details and lists include the rejection reason when applicable.
  - The suggestion status update endpoint accepts a request body with status and optional reason.

- Documentation
  - Clarified terminology and descriptions around rejection reasons in related models.

- Chores
  - Added database support for storing rejected suggestions and their reasons.
  - Introduced an archive table for published events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->