### PR TITLE
[Refactor]: Social-signup event

### DIFF
--- a/sseudam-clients/notification/src/main/kotlin/com/sseudam/client/discord/DiscordClientSender.kt
+++ b/sseudam-clients/notification/src/main/kotlin/com/sseudam/client/discord/DiscordClientSender.kt
@@ -45,6 +45,9 @@ class DiscordClientSender(
 
             **이메일:** ${userProfile.email}
             **회원 ID:** ${userProfile.id}
+            **닉네임:** ${userProfile.nickname}
+            **이름:** ${userProfile.name}
+            **사용자 관심지역:** ${userProfile.address.site}
             **가입일시:** ${userProfile.createdAt.toLocalDate()} ${userProfile.createdAt.toLocalTime()}
             """.trimIndent()
 

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/AuthController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/AuthController.kt
@@ -4,7 +4,6 @@ import com.sseudam.auth.AuthenticationFacade
 import com.sseudam.auth.AuthenticationService
 import com.sseudam.auth.CredentialSocial
 import com.sseudam.client.oauth.OAuthService
-import com.sseudam.common.Address
 import com.sseudam.presentation.v1.annotation.ApiV1Controller
 import com.sseudam.presentation.v1.auth.request.LoginRequest
 import com.sseudam.presentation.v1.auth.request.RefreshTokenRequest
@@ -97,7 +96,7 @@ class AuthController(
                 credentialSocial =
                     CredentialSocial(
                         email = socialInfo.email,
-                        name = null,
+                        name = "",
                         socialId = socialInfo.id,
                         socialType = SocialType.APPLE,
                     ),
@@ -114,14 +113,7 @@ class AuthController(
         if (tempUser == null) {
             throw ErrorException(ErrorType.NOT_FOUND_DATA)
         } else {
-            userService.updateName(tempUser.key, request.name)
-            userService.updateAddress(
-                tempUser.key,
-                Address(
-                    city = request.address.split(" ")[1],
-                    site = request.address,
-                ),
-            )
+            userService.socialSignUp(tempUser, request.toNewUser(tempUser.socialId, tempUser.socialType, request.address))
         }
         return SignUpResponse("회원가입에 성공했습니다.")
     }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpRequest.kt
@@ -14,9 +14,9 @@ data class SignUpRequest(
     @Schema(description = "비밀번호", example = "password")
     val password: String,
     @Schema(description = "이름", example = "윤범차")
-    val name: String?,
+    val name: String,
     @Schema(description = "이름", example = "닉네임이야")
-    val nickname: String?,
+    val nickname: String,
 ) {
     fun toNewUser(password: String): NewUser =
         NewUser(

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpSocialRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpSocialRequest.kt
@@ -3,6 +3,7 @@ package com.sseudam.presentation.v1.auth.request
 import com.sseudam.auth.AuthorityType
 import com.sseudam.auth.GrantedAuthority
 import com.sseudam.auth.NewAuthenticationSocial
+import com.sseudam.common.Address
 import com.sseudam.user.NewUser
 import com.sseudam.user.SocialType
 import io.swagger.v3.oas.annotations.media.Schema
@@ -26,6 +27,23 @@ data class SignUpSocialRequest(
             socialId = socialId,
             socialType = socialType,
             address = null,
+        )
+
+    fun toNewUser(
+        socialId: String,
+        socialType: SocialType,
+        address: String,
+    ): NewUser =
+        NewUser(
+            email = email,
+            name = name,
+            socialId = socialId,
+            socialType = socialType,
+            address =
+                Address(
+                    city = address.split(" ")[1],
+                    site = address,
+                ),
         )
 
     fun toNewAuthenticationSocial(

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpSocialRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/auth/request/SignUpSocialRequest.kt
@@ -32,7 +32,7 @@ data class SignUpSocialRequest(
     fun toNewUser(
         socialId: String,
         socialType: SocialType,
-        address: String,
+        site: String,
     ): NewUser =
         NewUser(
             email = email,
@@ -41,8 +41,8 @@ data class SignUpSocialRequest(
             socialType = socialType,
             address =
                 Address(
-                    city = address.split(" ")[1],
-                    site = address,
+                    city = site.split(" ").getOrNull(1) ?: "",
+                    site = site,
                 ),
         )
 

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/domain/trashspot/TrashSpotFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/domain/trashspot/TrashSpotFacadeTest.kt
@@ -60,7 +60,16 @@ class TrashSpotFacadeTest :
                         status = SuggestionStatus.WAITING,
                         createdAt = LocalDateTime.now(),
                     )
-                val userProfile = UserProfile(id = 123L, key = "k", email = "e@example.com", name = "u", nickname = "nick", createdAt = LocalDateTime.now())
+                val userProfile =
+                    UserProfile(
+                        id = 123L,
+                        key = "k",
+                        email = "e@example.com",
+                        name = "u",
+                        nickname = "nick",
+                        address = spot.address,
+                        createdAt = LocalDateTime.now(),
+                    )
 
                 every { service.findBy(1L) } returns spot
                 every { imageService.findBySpotId(1L) } returns listOf(image)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/CredentialSocial.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/auth/CredentialSocial.kt
@@ -4,7 +4,7 @@ import com.sseudam.user.SocialType
 
 data class CredentialSocial(
     val email: String,
-    val name: String?,
+    val name: String,
     val socialId: String,
     val socialType: SocialType,
 )

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/NewUser.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/NewUser.kt
@@ -13,7 +13,7 @@ import com.sseudam.common.Address
  * @property socialType 소셜 타입
  */
 data class NewUser(
-    val name: String?,
+    val name: String,
     val nickname: String? = null,
     val address: Address?,
     val email: String,

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserEventListener.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserEventListener.kt
@@ -18,7 +18,7 @@ class UserEventListener(
     private val discordClient: DiscordClient,
 ) {
     @ApplicationModuleListener(condition = "#event.userId != null")
-    fun onCreatePetListener(event: UserCreatedEvent) {
+    fun onCreatePetListener(event: UserSignUpEvent) {
         val (currentYear, currentMonth) = LocalDate.now().let { it.year to it.month }
 
         val pets = petReader.readAllLatestSeasonPets(currentYear, currentMonth)
@@ -29,7 +29,7 @@ class UserEventListener(
     }
 
     @ApplicationModuleListener(condition = "#event.userId != null")
-    fun onDiscordNotificationListener(event: UserCreatedEvent) {
+    fun onDiscordNotificationListener(event: UserSignUpEvent) {
         val userProfile =
             userReader.readUserProfile(event.userId)
                 ?: throw ErrorException(ErrorType.NOT_FOUND_USER)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserProfile.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserProfile.kt
@@ -1,5 +1,6 @@
 package com.sseudam.user
 
+import com.sseudam.common.Address
 import java.time.LocalDateTime
 
 data class UserProfile(
@@ -8,5 +9,6 @@ data class UserProfile(
     val email: String,
     val name: String?,
     val nickname: String,
+    val address: Address,
     val createdAt: LocalDateTime,
 )

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
@@ -21,9 +21,20 @@ class UserService(
         txAdvice.write {
             userValidator.verifyEmail(newUser.email)
             val createdUser = userAppender.create(newUser)
-            applicationEventPublisher.publishEvent(UserCreatedEvent(userId = createdUser.id))
             return@write createdUser
         }
+
+    fun socialSignUp(
+        socialUser: SocialUser,
+        newUser: NewUser,
+    ) = txAdvice.write {
+        updateName(socialUser.key, newUser.name)
+        updateAddress(
+            socialUser.key,
+            newUser.address ?: Address(city = "", site = ""),
+        )
+        applicationEventPublisher.publishEvent(UserCreatedEvent(userId = socialUser.id))
+    }
 
     fun getProfile(userId: Long): UserProfile? = userReader.readUserProfile(userId)
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
@@ -32,7 +32,7 @@ class UserService(
         newUser.address?.let { address ->
             updateAddress(socialUser.key, address)
         }
-        applicationEventPublisher.publishEvent(UserCreatedEvent(userId = socialUser.id))
+        applicationEventPublisher.publishEvent(UserSignUpEvent(userId = socialUser.id))
     }
 
     fun getProfile(userId: Long): UserProfile? = userReader.readUserProfile(userId)

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserService.kt
@@ -29,10 +29,9 @@ class UserService(
         newUser: NewUser,
     ) = txAdvice.write {
         updateName(socialUser.key, newUser.name)
-        updateAddress(
-            socialUser.key,
-            newUser.address ?: Address(city = "", site = ""),
-        )
+        newUser.address?.let { address ->
+            updateAddress(socialUser.key, address)
+        }
         applicationEventPublisher.publishEvent(UserCreatedEvent(userId = socialUser.id))
     }
 

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserSignUpEvent.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/user/UserSignUpEvent.kt
@@ -1,5 +1,5 @@
 package com.sseudam.user
 
-data class UserCreatedEvent(
+data class UserSignUpEvent(
     val userId: Long,
 )

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/user/UserEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/user/UserEntity.kt
@@ -72,6 +72,7 @@ class UserEntity(
             email = email,
             name = name,
             nickname = nickname ?: "",
+            address = address,
             createdAt = createdAt,
         )
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #228 

## 📌 작업 내용 및 특이 사항

- 22f7bb444c8cea94007431d6ad1c065f096c8893: 사용자 생성이 아닌 소셜 회원가입 로직에 이벤트 로직 이동 

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profiles now include address information for richer profile displays.
  * Discord notifications for new users now include nickname, name, and preferred area.

* **Refactor**
  * Social sign-up consolidated into a single unified flow for Apple and other providers.
  * Sign-up now requires name and nickname to improve data completeness.
  * Apple social login treats missing names as empty strings for consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->