### PR TITLE
[Test] Auth Controller & Application Layer Test Code

### DIFF
--- a/sseudam-core/core-api/build.gradle.kts
+++ b/sseudam-core/core-api/build.gradle.kts
@@ -161,6 +161,7 @@ dependencies {
     testImplementation(project(":sseudam-tests:api-docs"))
     testImplementation(project(":sseudam-tests:test-helper"))
     testImplementation(testFixtures(project(":sseudam-tests:test-container")))
+    testImplementation(libs.bundles.openfeign)
 }
 
 dependencyManagement {

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationFacadeTest.kt
@@ -1,0 +1,129 @@
+package com.sseudam.application.auth
+
+import com.sseudam.DevelopTest
+import com.sseudam.auth.AuthenticationFacade
+import com.sseudam.auth.AuthenticationService
+import com.sseudam.auth.Token
+import com.sseudam.auth.command.CredentialSocialCommand
+import com.sseudam.user.SocialType
+import com.sseudam.user.SocialUser
+import com.sseudam.user.User
+import com.sseudam.user.UserService
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@DevelopTest
+class AuthenticationFacadeTest :
+    DescribeSpec({
+        val authenticationService: AuthenticationService = mockk()
+        val userService: UserService = mockk()
+        val authenticationFacade = AuthenticationFacade(userService, authenticationService)
+
+        describe("소셜 로그인") {
+            context("기존 사용자가 존재하고 이름이 있는 경우") {
+                it("기존 사용자로 로그인하고 isNewUser는 false를 반환한다") {
+                    val existingUser = SocialUser(1L, "userKey", "기존유저", "socialId123", SocialType.KAKAO)
+                    val token = Token("accessToken", "refreshToken")
+                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "기존유저", "socialId123", SocialType.KAKAO)
+
+                    every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
+                    every { authenticationService.socialLogin("device123", existingUser) } returns token
+
+                    val (isNewUser, resultToken) = authenticationFacade.socialLogin("device123", credentialSocial)
+
+                    isNewUser shouldBe false
+                    resultToken shouldBe token
+                    verify { authenticationService.socialLogin("device123", existingUser) }
+                }
+            }
+
+            context("기존 사용자가 존재하지만 이름이 비어있는 경우") {
+                it("기존 사용자로 로그인하지만 isNewUser는 true를 반환한다") {
+                    val existingUser = SocialUser(1L, "userKey", "", "socialId123", SocialType.KAKAO)
+                    val token = Token("accessToken", "refreshToken")
+                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "", "socialId123", SocialType.KAKAO)
+
+                    every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
+                    every { authenticationService.socialLogin("device123", existingUser) } returns token
+
+                    val (isNewUser, resultToken) = authenticationFacade.socialLogin("device123", credentialSocial)
+
+                    isNewUser shouldBe true
+                    resultToken shouldBe token
+                }
+            }
+
+            context("기존 사용자가 존재하지만 이름이 null인 경우") {
+                it("기존 사용자로 로그인하지만 isNewUser는 true를 반환한다") {
+                    val existingUser = SocialUser(1L, "userKey", null, "socialId123", SocialType.KAKAO)
+                    val token = Token("accessToken", "refreshToken")
+                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "", "socialId123", SocialType.KAKAO)
+
+                    every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
+                    every { authenticationService.socialLogin("device123", existingUser) } returns token
+
+                    val (isNewUser, resultToken) = authenticationFacade.socialLogin("device123", credentialSocial)
+
+                    isNewUser shouldBe true
+                    resultToken shouldBe token
+                }
+            }
+
+            context("신규 사용자인 경우") {
+                it("새로운 사용자를 생성하고 로그인하며 isNewUser는 true를 반환한다") {
+                    val newUser = User(1L, "newUserKey")
+                    val token = Token("accessToken", "refreshToken")
+                    val credentialSocial = CredentialSocialCommand("test@apple.com", "신규유저", "socialId456", SocialType.APPLE)
+
+                    every { userService.getSocialUserByEmail("test@apple.com") } returns null
+                    every { userService.create(any()) } returns newUser
+                    every { authenticationService.socialLogin("device123", any()) } returns token
+
+                    val (isNewUser, resultToken) = authenticationFacade.socialLogin("device123", credentialSocial)
+
+                    isNewUser shouldBe true
+                    resultToken shouldBe token
+                    verify { userService.create(any()) }
+                    verify { authenticationService.socialLogin("device123", any()) }
+                }
+            }
+
+            context("deviceId가 빈 문자열인 경우") {
+                it("정상적으로 로그인을 처리한다") {
+                    val existingUser = SocialUser(1L, "userKey", "유저", "socialId123", SocialType.KAKAO)
+                    val token = Token("accessToken", "refreshToken")
+                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "유저", "socialId123", SocialType.KAKAO)
+
+                    every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
+                    every { authenticationService.socialLogin("", existingUser) } returns token
+
+                    val (isNewUser, resultToken) = authenticationFacade.socialLogin("", credentialSocial)
+
+                    isNewUser shouldBe false
+                    resultToken shouldBe token
+                }
+            }
+        }
+
+        describe("신규 소셜 사용자 생성") {
+            it("새로운 소셜 사용자를 생성하고 isUserNew는 true를 반환한다") {
+                val newUser = User(1L, "newUserKey")
+                val credentialSocial = CredentialSocialCommand("test@kakao.com", "신규유저", "socialId789", SocialType.KAKAO)
+
+                every { userService.create(any()) } returns newUser
+
+                val (socialUser, isUserNew) = authenticationFacade.createNewSocialUser(credentialSocial)
+
+                isUserNew shouldBe true
+                socialUser.id shouldBe 1L
+                socialUser.key shouldBe "newUserKey"
+                socialUser.name shouldBe "신규유저"
+                socialUser.socialId shouldBe "socialId789"
+                socialUser.socialType shouldBe SocialType.KAKAO
+                verify { userService.create(any()) }
+            }
+        }
+    })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationServiceTest.kt
@@ -1,0 +1,241 @@
+package com.sseudam.application.auth
+
+import com.sseudam.DevelopTest
+import com.sseudam.auth.AuthenticationService
+import com.sseudam.auth.AuthorityType
+import com.sseudam.auth.Token
+import com.sseudam.auth.command.CredentialSseudamCommand
+import com.sseudam.auth.component.AuthenticationProcessor
+import com.sseudam.auth.dto.GrantedAuthority
+import com.sseudam.user.SocialType
+import com.sseudam.user.SocialUser
+import com.sseudam.user.User
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@DevelopTest
+class AuthenticationServiceTest :
+    DescribeSpec({
+        val authenticationProcessor: AuthenticationProcessor = mockk()
+        val authenticationService = AuthenticationService(authenticationProcessor)
+
+        describe("일반 로그인") {
+            context("유효한 사용자와 deviceId가 있는 경우") {
+                it("토큰을 생성하고 반환한다") {
+                    val user = User(1L, "userKey")
+                    val credential = CredentialSseudamCommand("test@test.com", "password")
+                    val token = Token("accessToken", "refreshToken")
+
+                    every { authenticationProcessor.login("device123", user, credential) } returns token
+
+                    val result = authenticationService.login("device123", user, credential)
+
+                    result shouldBe token
+                    verify { authenticationProcessor.login("device123", user, credential) }
+                }
+            }
+
+            context("deviceId가 null인 경우") {
+                it("null deviceId로 토큰을 생성한다") {
+                    val user = User(1L, "userKey")
+                    val credential = CredentialSseudamCommand("test@test.com", "password")
+                    val token = Token("accessToken", "refreshToken")
+
+                    every { authenticationProcessor.login(null, user, credential) } returns token
+
+                    val result = authenticationService.login(null, user, credential)
+
+                    result shouldBe token
+                    verify { authenticationProcessor.login(null, user, credential) }
+                }
+            }
+        }
+
+        describe("소셜 로그인") {
+            context("유효한 소셜 사용자인 경우") {
+                it("토큰을 생성하고 반환한다") {
+                    val socialUser = SocialUser(1L, "userKey", "카카오유저", "socialId123", SocialType.KAKAO)
+                    val token = Token("accessToken", "refreshToken")
+
+                    every { authenticationProcessor.login("device123", socialUser) } returns token
+
+                    val result = authenticationService.socialLogin("device123", socialUser)
+
+                    result shouldBe token
+                    verify { authenticationProcessor.login("device123", socialUser) }
+                }
+            }
+
+            context("빈 deviceId인 경우") {
+                it("빈 deviceId로 토큰을 생성한다") {
+                    val socialUser = SocialUser(1L, "userKey", "애플유저", "socialId456", SocialType.APPLE)
+                    val token = Token("accessToken", "refreshToken")
+
+                    every { authenticationProcessor.login("", socialUser) } returns token
+
+                    val result = authenticationService.socialLogin("", socialUser)
+
+                    result shouldBe token
+                }
+            }
+        }
+
+        describe("토큰 재발급") {
+            context("유효한 refreshToken인 경우") {
+                it("새로운 토큰을 반환한다") {
+                    val refreshToken = "validRefreshToken"
+                    val newToken = Token("newAccessToken", "newRefreshToken")
+
+                    every { authenticationProcessor.renew(refreshToken) } returns newToken
+
+                    val result = authenticationService.renew(refreshToken)
+
+                    result shouldBe newToken
+                    verify { authenticationProcessor.renew(refreshToken) }
+                }
+            }
+
+            context("빈 refreshToken인 경우") {
+                it("processor를 호출한다") {
+                    val refreshToken = ""
+                    val token = Token("accessToken", "refreshToken")
+
+                    every { authenticationProcessor.renew(refreshToken) } returns token
+
+                    val result = authenticationService.renew(refreshToken)
+
+                    result shouldBe token
+                }
+            }
+        }
+
+        describe("로그아웃") {
+            context("유효한 토큰인 경우") {
+                it("userKey를 반환한다") {
+                    val token = "validToken"
+                    val userKey = "userKey123"
+
+                    every { authenticationProcessor.remove(token) } returns userKey
+
+                    val result = authenticationService.logout(token)
+
+                    result shouldBe userKey
+                    verify { authenticationProcessor.remove(token) }
+                }
+            }
+
+            context("빈 토큰인 경우") {
+                it("processor를 호출한다") {
+                    val token = ""
+                    val userKey = "userKey"
+
+                    every { authenticationProcessor.remove(token) } returns userKey
+
+                    val result = authenticationService.logout(token)
+
+                    result shouldBe userKey
+                }
+            }
+        }
+
+        describe("회원 탈퇴") {
+            context("유효한 userKey인 경우") {
+                it("토큰을 제거한다") {
+                    val userKey = "userKey123"
+
+                    every { authenticationProcessor.withdrawal(userKey) } returns Unit
+
+                    authenticationService.withdrawUser(userKey)
+
+                    verify { authenticationProcessor.withdrawal(userKey) }
+                }
+            }
+
+            context("빈 userKey인 경우") {
+                it("processor를 호출한다") {
+                    val userKey = ""
+
+                    every { authenticationProcessor.withdrawal(userKey) } returns Unit
+
+                    authenticationService.withdrawUser(userKey)
+
+                    verify { authenticationProcessor.withdrawal(userKey) }
+                }
+            }
+        }
+
+        describe("관리자 로그인") {
+            context("유효한 adminId인 경우") {
+                it("관리자 권한으로 토큰을 생성한다") {
+                    val adminId = 1L
+                    val token = Token("adminAccessToken", "adminRefreshToken")
+                    val authorities = listOf(GrantedAuthority(AuthorityType.ADMIN))
+
+                    every { authenticationProcessor.adminLogin(adminId, authorities) } returns token
+
+                    val result = authenticationService.adminLogin(adminId)
+
+                    result shouldBe token
+                    verify { authenticationProcessor.adminLogin(adminId, authorities) }
+                }
+            }
+
+            context("adminId가 0인 경우") {
+                it("processor를 호출한다") {
+                    val adminId = 0L
+                    val token = Token("accessToken", "refreshToken")
+
+                    every { authenticationProcessor.adminLogin(adminId, any()) } returns token
+
+                    val result = authenticationService.adminLogin(adminId)
+
+                    result shouldBe token
+                }
+            }
+        }
+
+        describe("관리자 토큰 재발급") {
+            context("유효한 refreshToken인 경우") {
+                it("새로운 관리자 토큰을 반환한다") {
+                    val refreshToken = "adminRefreshToken"
+                    val newToken = Token("newAdminAccessToken", "newAdminRefreshToken")
+
+                    every { authenticationProcessor.adminRenew(refreshToken) } returns newToken
+
+                    val result = authenticationService.adminReissue(refreshToken)
+
+                    result shouldBe newToken
+                    verify { authenticationProcessor.adminRenew(refreshToken) }
+                }
+            }
+        }
+
+        describe("관리자 로그아웃") {
+            context("유효한 accessToken인 경우") {
+                it("관리자 토큰을 제거한다") {
+                    val accessToken = "adminAccessToken"
+
+                    every { authenticationProcessor.adminLogout(accessToken) } returns Unit
+
+                    authenticationService.adminLogout(accessToken)
+
+                    verify { authenticationProcessor.adminLogout(accessToken) }
+                }
+            }
+
+            context("빈 accessToken인 경우") {
+                it("processor를 호출한다") {
+                    val accessToken = ""
+
+                    every { authenticationProcessor.adminLogout(accessToken) } returns Unit
+
+                    authenticationService.adminLogout(accessToken)
+
+                    verify { authenticationProcessor.adminLogout(accessToken) }
+                }
+            }
+        }
+    })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/OAuthServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/OAuthServiceTest.kt
@@ -1,0 +1,151 @@
+package com.sseudam.application.auth
+
+import com.sseudam.DevelopTest
+import com.sseudam.client.oauth.AppleClient
+import com.sseudam.client.oauth.AppleClientResult
+import com.sseudam.client.oauth.KaKaoClient
+import com.sseudam.client.oauth.KaKaoClientResult
+import com.sseudam.client.oauth.OAuthService
+import com.sseudam.support.error.AuthenticationErrorException
+import com.sseudam.support.error.AuthenticationErrorType
+import feign.FeignException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@DevelopTest
+class OAuthServiceTest :
+    DescribeSpec({
+        val kaKaoClient: KaKaoClient = mockk()
+        val appleClient: AppleClient = mockk()
+        val oAuthService = OAuthService(kaKaoClient, appleClient)
+
+        describe("카카오 사용자 정보 조회") {
+            context("유효한 토큰인 경우") {
+                it("카카오 사용자 정보를 반환한다") {
+                    val token = "valid_kakao_token"
+                    val expected = KaKaoClientResult("kakaoId123", "test@kakao.com", "카카오유저", "닉네임")
+
+                    every { kaKaoClient.getUserInfo(token) } returns expected
+
+                    val result = oAuthService.getKaKaoUserInfo(token)
+
+                    result shouldBe expected
+                    verify { kaKaoClient.getUserInfo(token) }
+                }
+            }
+
+            context("401 에러가 발생한 경우") {
+                it("INVALID_KAKAO_TOKEN 예외를 던진다") {
+                    val token = "invalid_token"
+                    val feignException: FeignException = mockk()
+
+                    every { feignException.status() } returns 401
+                    every { kaKaoClient.getUserInfo(token) } throws feignException
+
+                    val exception =
+                        shouldThrow<AuthenticationErrorException> {
+                            oAuthService.getKaKaoUserInfo(token)
+                        }
+
+                    exception.authenticationErrorType shouldBe AuthenticationErrorType.INVALID_KAKAO_TOKEN
+                }
+            }
+
+            context("401이 아닌 다른 에러가 발생한 경우") {
+                it("INVALID_KAKAO_TOKEN 예외를 메시지와 함께 던진다") {
+                    val token = "error_token"
+                    val feignException: FeignException = mockk()
+
+                    every { feignException.status() } returns 500
+                    every { feignException.message } returns "Internal Server Error"
+                    every { kaKaoClient.getUserInfo(token) } throws feignException
+
+                    val exception =
+                        shouldThrow<AuthenticationErrorException> {
+                            oAuthService.getKaKaoUserInfo(token)
+                        }
+
+                    exception.authenticationErrorType shouldBe AuthenticationErrorType.INVALID_KAKAO_TOKEN
+                    exception.data shouldBe "Internal Server Error"
+                }
+            }
+
+            context("빈 토큰인 경우") {
+                it("카카오 클라이언트를 호출한다") {
+                    val token = ""
+                    val expected = KaKaoClientResult("id", "email@test.com", "name", "nickname")
+
+                    every { kaKaoClient.getUserInfo(token) } returns expected
+
+                    val result = oAuthService.getKaKaoUserInfo(token)
+
+                    result shouldBe expected
+                }
+            }
+        }
+
+        describe("애플 사용자 정보 조회") {
+            context("유효한 토큰인 경우") {
+                it("애플 사용자 정보를 반환한다") {
+                    val token = "valid_apple_token"
+                    val expected = AppleClientResult("appleId123", "test@apple.com")
+
+                    every { appleClient.verify(token) } returns true
+                    every { appleClient.getUserInfo(token) } returns expected
+
+                    val result = oAuthService.getAppleUserInfo(token)
+
+                    result shouldBe expected
+                    verify { appleClient.verify(token) }
+                    verify { appleClient.getUserInfo(token) }
+                }
+            }
+
+            context("토큰 검증에 실패한 경우") {
+                it("INVALID_APPLE_TOKEN 예외를 던진다") {
+                    val token = "invalid_apple_token"
+
+                    every { appleClient.verify(token) } returns false
+
+                    val exception =
+                        shouldThrow<AuthenticationErrorException> {
+                            oAuthService.getAppleUserInfo(token)
+                        }
+
+                    exception.authenticationErrorType shouldBe AuthenticationErrorType.INVALID_APPLE_TOKEN
+                }
+            }
+
+            context("빈 토큰인 경우") {
+                it("INVALID_APPLE_TOKEN 예외를 던진다") {
+                    val token = ""
+
+                    every { appleClient.verify(token) } returns false
+
+                    val exception =
+                        shouldThrow<AuthenticationErrorException> {
+                            oAuthService.getAppleUserInfo(token)
+                        }
+
+                    exception.authenticationErrorType shouldBe AuthenticationErrorType.INVALID_APPLE_TOKEN
+                }
+            }
+
+            context("토큰 검증은 성공했지만 사용자 정보 조회 중 예외가 발생한 경우") {
+                it("예외를 그대로 전파한다") {
+                    val token = "valid_but_error_token"
+
+                    every { appleClient.verify(token) } returns true
+                    every { appleClient.getUserInfo(token) } throws RuntimeException("Unexpected error")
+
+                    shouldThrow<RuntimeException> {
+                        oAuthService.getAppleUserInfo(token)
+                    }
+                }
+            }
+        }
+    })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotFacadeTest.kt
@@ -1,4 +1,4 @@
-package com.sseudam.domain.trashspot
+package com.sseudam.application.trashspot
 
 import com.sseudam.DevelopTest
 import com.sseudam.common.GeoConverter

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotServiceTest.kt
@@ -1,4 +1,4 @@
-package com.sseudam.domain.trashspot
+package com.sseudam.application.trashspot
 
 import com.sseudam.DevelopTest
 import com.sseudam.common.Address

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/auth/AuthControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/auth/AuthControllerTest.kt
@@ -1,0 +1,314 @@
+package com.sseudam.presentation.v1.auth
+
+import com.sseudam.RestDocsTest
+import com.sseudam.auth.AuthenticationFacade
+import com.sseudam.auth.AuthenticationService
+import com.sseudam.auth.Token
+import com.sseudam.client.oauth.AppleClientResult
+import com.sseudam.client.oauth.KaKaoClientResult
+import com.sseudam.client.oauth.OAuthService
+import com.sseudam.docs.RestDocsTestSuite
+import com.sseudam.docs.support.BOOLEAN
+import com.sseudam.docs.support.DocsTag
+import com.sseudam.docs.support.MockMvcExtensions.makeDocument
+import com.sseudam.docs.support.RestDocsUtils.requestBody
+import com.sseudam.docs.support.RestDocsUtils.responseBody
+import com.sseudam.docs.support.STRING
+import com.sseudam.docs.support.type
+import com.sseudam.presentation.v1.auth.request.LoginRequest
+import com.sseudam.presentation.v1.auth.request.RefreshTokenRequest
+import com.sseudam.presentation.v1.auth.request.SignUpRequest
+import com.sseudam.presentation.v1.auth.request.SignUpSocialRequest
+import com.sseudam.presentation.v1.auth.request.TokenRequest
+import com.sseudam.user.SocialType
+import com.sseudam.user.SocialUser
+import com.sseudam.user.UserCredentials
+import com.sseudam.user.UserService
+import io.mockk.every
+import io.mockk.mockk
+import io.restassured.http.ContentType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@RestDocsTest
+class AuthControllerTest : RestDocsTestSuite() {
+    private lateinit var authController: AuthController
+    private lateinit var passwordEncoder: PasswordEncoder
+    private lateinit var authenticationService: AuthenticationService
+    private lateinit var authenticationFacade: AuthenticationFacade
+    private lateinit var oAuthService: OAuthService
+    private lateinit var userService: UserService
+
+    @BeforeEach
+    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+        passwordEncoder = mockk()
+        authenticationService = mockk()
+        authenticationFacade = mockk()
+        oAuthService = mockk()
+        userService = mockk()
+        authController =
+            AuthController(
+                passwordEncoder = passwordEncoder,
+                authenticationService = authenticationService,
+                authenticationFacade = authenticationFacade,
+                oAuthService = oAuthService,
+                userService = userService,
+            )
+        mockMvcSpec = mockController(authController)
+    }
+
+    @DisplayName("로그인 - 200")
+    @Test
+    fun t1() {
+        val userCredential = UserCredentials(1L, "userKey", "test@test.com", "{noop}password")
+        val token = Token("accessToken", "refreshToken")
+
+        every { userService.getUserCredential(any()) } returns userCredential
+        every { passwordEncoder.matches(any(), any()) } returns true
+        every { authenticationService.login(any(), any(), any()) } returns token
+
+        val request = LoginRequest("test@test.com", "password")
+
+        val response =
+            given()
+                .header("X-DEVICE-ID", "device123")
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/auth/test-login")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "로그인",
+            DocsTag.AUTH,
+            requestBody =
+                requestBody(
+                    "loginId" type STRING means "로그인 아이디" example "test@test.com",
+                    "password" type STRING means "비밀번호" example "password",
+                ),
+            responseSchema = "TokenResponse",
+            responseBody =
+                responseBody(
+                    "isTemporaryToken" type BOOLEAN means "임시 토큰 여부",
+                    "accessToken" type STRING means "액세스 토큰",
+                    "refreshToken" type STRING means "리프레시 토큰",
+                ),
+        )
+    }
+
+    @DisplayName("회원가입 - 200")
+    @Test
+    fun t2() {
+        every { passwordEncoder.encode(any()) } returns "encodedPassword"
+        every { userService.create(any()) } returns mockk()
+
+        val request = SignUpRequest("test@test.com", "password", "윤범차", "닉네임이야")
+
+        val response =
+            given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/auth/signup")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "회원가입",
+            DocsTag.AUTH,
+            requestBody =
+                requestBody(
+                    "email" type STRING means "이메일" example "test@test.com",
+                    "password" type STRING means "비밀번호" example "password",
+                    "name" type STRING means "이름" example "윤범차",
+                    "nickname" type STRING means "닉네임" example "닉네임이야",
+                ),
+            responseSchema = "SignUpResponse",
+            responseBody =
+                responseBody(
+                    "message" type STRING means "회원가입 메시지",
+                ),
+        )
+    }
+
+    @DisplayName("카카오 소셜 로그인 - 200")
+    @Test
+    fun t3() {
+        val socialInfo = KaKaoClientResult("kakaoId123", "test@kakao.com", "카카오유저", "카카오닉네임")
+        val token = Token("accessToken", "refreshToken")
+
+        every { oAuthService.getKaKaoUserInfo(any()) } returns socialInfo
+        every { authenticationFacade.socialLogin(any(), any()) } returns Pair(false, token)
+
+        val request = TokenRequest("kakao_access_token")
+
+        val response =
+            given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/auth/social-login/kakao")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "카카오 소셜 로그인",
+            DocsTag.AUTH,
+            requestBody =
+                requestBody(
+                    "token" type STRING means "카카오 액세스 토큰" example "kakao_access_token",
+                ),
+            responseSchema = "TokenResponse",
+            responseBody =
+                responseBody(
+                    "isTemporaryToken" type BOOLEAN means "임시 토큰 여부",
+                    "accessToken" type STRING means "액세스 토큰",
+                    "refreshToken" type STRING means "리프레시 토큰",
+                ),
+        )
+    }
+
+    @DisplayName("애플 소셜 로그인 - 200")
+    @Test
+    fun t4() {
+        val socialInfo = AppleClientResult("appleId123", "test@apple.com")
+        val token = Token("accessToken", "refreshToken")
+
+        every { oAuthService.getAppleUserInfo(any()) } returns socialInfo
+        every { authenticationFacade.socialLogin(any(), any()) } returns Pair(false, token)
+
+        val request = TokenRequest("apple_id_token")
+
+        val response =
+            given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/auth/social-login/apple")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "애플 소셜 로그인",
+            DocsTag.AUTH,
+            requestBody =
+                requestBody(
+                    "token" type STRING means "애플 ID 토큰" example "apple_id_token",
+                ),
+            responseSchema = "TokenResponse",
+            responseBody =
+                responseBody(
+                    "isTemporaryToken" type BOOLEAN means "임시 토큰 여부",
+                    "accessToken" type STRING means "액세스 토큰",
+                    "refreshToken" type STRING means "리프레시 토큰",
+                ),
+        )
+    }
+
+    @DisplayName("소셜 회원가입 - 200")
+    @Test
+    fun t5() {
+        val tempUser = SocialUser(1L, "userKey", "카카오유저", "kakaoId123", SocialType.KAKAO)
+
+        every { userService.getSocialUserByEmail(any()) } returns tempUser
+        every { userService.socialSignUp(any(), any()) } returns Unit
+
+        val request = SignUpSocialRequest("test@kakao.com", "쓰담", "서울시 영등포구 여의도동 123-45")
+
+        val response =
+            given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/auth/social-signup")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "소셜 회원가입",
+            DocsTag.AUTH,
+            requestBody =
+                requestBody(
+                    "email" type STRING means "소셜 이메일" example "test@kakao.com",
+                    "name" type STRING means "사용자 닉네임" example "쓰담",
+                    "address" type STRING means "관심 지역" example "서울시 영등포구 여의도동 123-45",
+                ),
+            responseSchema = "SignUpResponse",
+            responseBody =
+                responseBody(
+                    "message" type STRING means "회원가입 메시지",
+                ),
+        )
+    }
+
+    @DisplayName("로그아웃 - 200")
+    @Test
+    fun t6() {
+        every { authenticationService.logout(any()) } returns "userKey"
+
+        val request = TokenRequest("accessToken")
+
+        val response =
+            given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/auth/logout")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "로그아웃",
+            DocsTag.AUTH,
+            requestBody =
+                requestBody(
+                    "token" type STRING means "액세스 토큰" example "accessToken",
+                ),
+            responseSchema = "LogoutResponse",
+            responseBody =
+                responseBody(
+                    "message" type STRING means "로그아웃 메시지",
+                ),
+        )
+    }
+
+    @DisplayName("토큰 재발급 - 200")
+    @Test
+    fun t7() {
+        val token = Token("newAccessToken", "newRefreshToken")
+
+        every { authenticationService.renew(any()) } returns token
+
+        val request = RefreshTokenRequest("refreshToken")
+
+        val response =
+            given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/auth/reissue")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "토큰 재발급",
+            DocsTag.AUTH,
+            requestBody =
+                requestBody(
+                    "refreshToken" type STRING means "리프레시 토큰" example "refreshToken",
+                ),
+            responseSchema = "TokenResponse",
+            responseBody =
+                responseBody(
+                    "isTemporaryToken" type BOOLEAN means "임시 토큰 여부",
+                    "accessToken" type STRING means "액세스 토큰",
+                    "refreshToken" type STRING means "리프레시 토큰",
+                ),
+        )
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #199 

## 📌 작업 내용 및 특이 사항

- d61bace2ac1e3c629e01a71b9be9f1dc0c2b2a0f: RestDocs 기반 Auth 테스트 코드 작성
- 3cffc48ff9528393428e4c199c57d3b84ec07fd6: 비즈니스 로직 기반 Auth 테스트 코드 작성

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive tests for authentication flows, including login, signup, social login (Kakao/Apple), token renewal, logout, and user withdrawal.
  - Expanded coverage for OAuth interactions and authentication services.
  - Updated test package declarations for trash spot modules.

- Documentation
  - Generated API documentation for v1 authentication endpoints through test scenarios.

- Chores
  - Introduced additional test-time dependencies to support HTTP client mocking (OpenFeign).

Note: No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->