### PR TITLE
[Test] User Controller & Application Layer Test Code

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/user/UserController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/user/UserController.kt
@@ -32,9 +32,7 @@ class UserController(
 ) {
     @Operation(summary = "내 정보 조회", description = "내 정보를 조회합니다.")
     @GetMapping("/users/me")
-    fun me(
-        @Parameter(hidden = true, required = false) user: User,
-    ): UserProfileResponse {
+    fun me(user: User): UserProfileResponse {
         val userProfile = userService.getProfile(user.id) ?: throw ErrorException(ErrorType.NOT_FOUND_USER)
         return UserProfileResponse.of(userProfile)
     }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/DevelopTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/DevelopTest.kt
@@ -1,12 +1,27 @@
 package com.sseudam
 
+import io.sentry.spring.boot.jakarta.SentryAutoConfiguration
 import org.junit.jupiter.api.Tag
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestConstructor
 
 @Tag("develop")
 @SpringBootTest
-@ContextConfiguration(classes = [RedisContainersConfig::class])
+@EnableAutoConfiguration(
+    exclude = [
+        SentryAutoConfiguration::class,
+        DataSourceAutoConfiguration::class,
+        DataSourceTransactionManagerAutoConfiguration::class,
+        HibernateJpaAutoConfiguration::class,
+        FlywayAutoConfiguration::class,
+    ],
+)
+@ContextConfiguration(classes = [RedisContainersConfig::class, TestTxConfig::class])
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 annotation class DevelopTest

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/TestTxConfig.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/TestTxConfig.kt
@@ -1,0 +1,16 @@
+package com.sseudam
+
+import com.sseudam.support.tx.Tx
+import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.transaction.PlatformTransactionManager
+
+@TestConfiguration
+class TestTxConfig {
+    @Bean
+    fun platformTransactionManager(): PlatformTransactionManager = mockk(relaxed = true)
+
+    @Bean
+    fun tx(transactionManager: PlatformTransactionManager): Tx = Tx(Tx.TxAdvice(transactionManager))
+}

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationFacadeTest.kt
@@ -3,11 +3,9 @@ package com.sseudam.application.auth
 import com.sseudam.DevelopTest
 import com.sseudam.auth.AuthenticationFacade
 import com.sseudam.auth.AuthenticationService
-import com.sseudam.auth.Token
-import com.sseudam.auth.command.CredentialSocialCommand
+import com.sseudam.fixture.auth.AuthFixture
+import com.sseudam.fixture.user.UserFixture
 import com.sseudam.user.SocialType
-import com.sseudam.user.SocialUser
-import com.sseudam.user.User
 import com.sseudam.user.UserService
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -25,9 +23,9 @@ class AuthenticationFacadeTest :
         describe("소셜 로그인") {
             context("기존 사용자가 존재하고 이름이 있는 경우") {
                 it("기존 사용자로 로그인하고 isNewUser는 false를 반환한다") {
-                    val existingUser = SocialUser(1L, "userKey", "기존유저", "socialId123", SocialType.KAKAO)
-                    val token = Token("accessToken", "refreshToken")
-                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "기존유저", "socialId123", SocialType.KAKAO)
+                    val existingUser = AuthFixture.socialUser
+                    val token = AuthFixture.token
+                    val credentialSocial = AuthFixture.credentialSocialCommand
 
                     every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
                     every { authenticationService.socialLogin("device123", existingUser) } returns token
@@ -42,11 +40,11 @@ class AuthenticationFacadeTest :
 
             context("기존 사용자가 존재하지만 이름이 비어있는 경우") {
                 it("기존 사용자로 로그인하지만 isNewUser는 true를 반환한다") {
-                    val existingUser = SocialUser(1L, "userKey", "", "socialId123", SocialType.KAKAO)
-                    val token = Token("accessToken", "refreshToken")
-                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "", "socialId123", SocialType.KAKAO)
+                    val existingUser = AuthFixture.socialNewUser
+                    val token = AuthFixture.token
+                    val credentialSocial = AuthFixture.credentialNewSocialCommand
 
-                    every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
+                    every { userService.getSocialUserByEmail(credentialSocial.email) } returns existingUser
                     every { authenticationService.socialLogin("device123", existingUser) } returns token
 
                     val (isNewUser, resultToken) = authenticationFacade.socialLogin("device123", credentialSocial)
@@ -58,11 +56,11 @@ class AuthenticationFacadeTest :
 
             context("기존 사용자가 존재하지만 이름이 null인 경우") {
                 it("기존 사용자로 로그인하지만 isNewUser는 true를 반환한다") {
-                    val existingUser = SocialUser(1L, "userKey", null, "socialId123", SocialType.KAKAO)
-                    val token = Token("accessToken", "refreshToken")
-                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "", "socialId123", SocialType.KAKAO)
+                    val existingUser = AuthFixture.socialNewUser
+                    val token = AuthFixture.token
+                    val credentialSocial = AuthFixture.credentialNewSocialCommand
 
-                    every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
+                    every { userService.getSocialUserByEmail(credentialSocial.email) } returns existingUser
                     every { authenticationService.socialLogin("device123", existingUser) } returns token
 
                     val (isNewUser, resultToken) = authenticationFacade.socialLogin("device123", credentialSocial)
@@ -74,9 +72,9 @@ class AuthenticationFacadeTest :
 
             context("신규 사용자인 경우") {
                 it("새로운 사용자를 생성하고 로그인하며 isNewUser는 true를 반환한다") {
-                    val newUser = User(1L, "newUserKey")
-                    val token = Token("accessToken", "refreshToken")
-                    val credentialSocial = CredentialSocialCommand("test@apple.com", "신규유저", "socialId456", SocialType.APPLE)
+                    val newUser = UserFixture.user
+                    val token = AuthFixture.token
+                    val credentialSocial = AuthFixture.credentialNewSocialCommand
 
                     every { userService.getSocialUserByEmail("test@apple.com") } returns null
                     every { userService.create(any()) } returns newUser
@@ -93,9 +91,9 @@ class AuthenticationFacadeTest :
 
             context("deviceId가 빈 문자열인 경우") {
                 it("정상적으로 로그인을 처리한다") {
-                    val existingUser = SocialUser(1L, "userKey", "유저", "socialId123", SocialType.KAKAO)
-                    val token = Token("accessToken", "refreshToken")
-                    val credentialSocial = CredentialSocialCommand("test@kakao.com", "유저", "socialId123", SocialType.KAKAO)
+                    val existingUser = AuthFixture.socialUser
+                    val token = AuthFixture.token
+                    val credentialSocial = AuthFixture.credentialSocialCommand
 
                     every { userService.getSocialUserByEmail("test@kakao.com") } returns existingUser
                     every { authenticationService.socialLogin("", existingUser) } returns token
@@ -110,8 +108,8 @@ class AuthenticationFacadeTest :
 
         describe("신규 소셜 사용자 생성") {
             it("새로운 소셜 사용자를 생성하고 isUserNew는 true를 반환한다") {
-                val newUser = User(1L, "newUserKey")
-                val credentialSocial = CredentialSocialCommand("test@kakao.com", "신규유저", "socialId789", SocialType.KAKAO)
+                val newUser = UserFixture.user
+                val credentialSocial = AuthFixture.credentialNewSocialCommand
 
                 every { userService.create(any()) } returns newUser
 
@@ -119,10 +117,10 @@ class AuthenticationFacadeTest :
 
                 isUserNew shouldBe true
                 socialUser.id shouldBe 1L
-                socialUser.key shouldBe "newUserKey"
-                socialUser.name shouldBe "신규유저"
-                socialUser.socialId shouldBe "socialId789"
-                socialUser.socialType shouldBe SocialType.KAKAO
+                socialUser.key shouldBe "20251003_UK_d69fc385032246949285908cf6588a41"
+                socialUser.name shouldBe ""
+                socialUser.socialId shouldBe "socialId123"
+                socialUser.socialType shouldBe SocialType.APPLE
                 verify { userService.create(any()) }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/AuthenticationServiceTest.kt
@@ -2,14 +2,9 @@ package com.sseudam.application.auth
 
 import com.sseudam.DevelopTest
 import com.sseudam.auth.AuthenticationService
-import com.sseudam.auth.AuthorityType
-import com.sseudam.auth.Token
-import com.sseudam.auth.command.CredentialSseudamCommand
 import com.sseudam.auth.component.AuthenticationProcessor
-import com.sseudam.auth.dto.GrantedAuthority
-import com.sseudam.user.SocialType
-import com.sseudam.user.SocialUser
-import com.sseudam.user.User
+import com.sseudam.fixture.auth.AuthFixture
+import com.sseudam.fixture.user.UserFixture
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -25,9 +20,9 @@ class AuthenticationServiceTest :
         describe("일반 로그인") {
             context("유효한 사용자와 deviceId가 있는 경우") {
                 it("토큰을 생성하고 반환한다") {
-                    val user = User(1L, "userKey")
-                    val credential = CredentialSseudamCommand("test@test.com", "password")
-                    val token = Token("accessToken", "refreshToken")
+                    val user = UserFixture.user
+                    val credential = AuthFixture.credentialSseudamCommand
+                    val token = AuthFixture.token
 
                     every { authenticationProcessor.login("device123", user, credential) } returns token
 
@@ -40,9 +35,9 @@ class AuthenticationServiceTest :
 
             context("deviceId가 null인 경우") {
                 it("null deviceId로 토큰을 생성한다") {
-                    val user = User(1L, "userKey")
-                    val credential = CredentialSseudamCommand("test@test.com", "password")
-                    val token = Token("accessToken", "refreshToken")
+                    val user = UserFixture.user
+                    val credential = AuthFixture.credentialSseudamCommand
+                    val token = AuthFixture.token
 
                     every { authenticationProcessor.login(null, user, credential) } returns token
 
@@ -57,8 +52,8 @@ class AuthenticationServiceTest :
         describe("소셜 로그인") {
             context("유효한 소셜 사용자인 경우") {
                 it("토큰을 생성하고 반환한다") {
-                    val socialUser = SocialUser(1L, "userKey", "카카오유저", "socialId123", SocialType.KAKAO)
-                    val token = Token("accessToken", "refreshToken")
+                    val socialUser = AuthFixture.socialUser
+                    val token = AuthFixture.token
 
                     every { authenticationProcessor.login("device123", socialUser) } returns token
 
@@ -71,8 +66,8 @@ class AuthenticationServiceTest :
 
             context("빈 deviceId인 경우") {
                 it("빈 deviceId로 토큰을 생성한다") {
-                    val socialUser = SocialUser(1L, "userKey", "애플유저", "socialId456", SocialType.APPLE)
-                    val token = Token("accessToken", "refreshToken")
+                    val socialUser = AuthFixture.socialUser
+                    val token = AuthFixture.token
 
                     every { authenticationProcessor.login("", socialUser) } returns token
 
@@ -87,7 +82,7 @@ class AuthenticationServiceTest :
             context("유효한 refreshToken인 경우") {
                 it("새로운 토큰을 반환한다") {
                     val refreshToken = "validRefreshToken"
-                    val newToken = Token("newAccessToken", "newRefreshToken")
+                    val newToken = AuthFixture.token
 
                     every { authenticationProcessor.renew(refreshToken) } returns newToken
 
@@ -101,7 +96,7 @@ class AuthenticationServiceTest :
             context("빈 refreshToken인 경우") {
                 it("processor를 호출한다") {
                     val refreshToken = ""
-                    val token = Token("accessToken", "refreshToken")
+                    val token = AuthFixture.token
 
                     every { authenticationProcessor.renew(refreshToken) } returns token
 
@@ -171,8 +166,8 @@ class AuthenticationServiceTest :
             context("유효한 adminId인 경우") {
                 it("관리자 권한으로 토큰을 생성한다") {
                     val adminId = 1L
-                    val token = Token("adminAccessToken", "adminRefreshToken")
-                    val authorities = listOf(GrantedAuthority(AuthorityType.ADMIN))
+                    val token = AuthFixture.token
+                    val authorities = listOf(AuthFixture.grantedAuthority)
 
                     every { authenticationProcessor.adminLogin(adminId, authorities) } returns token
 
@@ -186,7 +181,7 @@ class AuthenticationServiceTest :
             context("adminId가 0인 경우") {
                 it("processor를 호출한다") {
                     val adminId = 0L
-                    val token = Token("accessToken", "refreshToken")
+                    val token = AuthFixture.token
 
                     every { authenticationProcessor.adminLogin(adminId, any()) } returns token
 
@@ -201,7 +196,7 @@ class AuthenticationServiceTest :
             context("유효한 refreshToken인 경우") {
                 it("새로운 관리자 토큰을 반환한다") {
                     val refreshToken = "adminRefreshToken"
-                    val newToken = Token("newAdminAccessToken", "newAdminRefreshToken")
+                    val newToken = AuthFixture.token
 
                     every { authenticationProcessor.adminRenew(refreshToken) } returns newToken
 

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/OAuthServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/auth/OAuthServiceTest.kt
@@ -2,10 +2,9 @@ package com.sseudam.application.auth
 
 import com.sseudam.DevelopTest
 import com.sseudam.client.oauth.AppleClient
-import com.sseudam.client.oauth.AppleClientResult
 import com.sseudam.client.oauth.KaKaoClient
-import com.sseudam.client.oauth.KaKaoClientResult
 import com.sseudam.client.oauth.OAuthService
+import com.sseudam.fixture.auth.AuthFixture
 import com.sseudam.support.error.AuthenticationErrorException
 import com.sseudam.support.error.AuthenticationErrorType
 import feign.FeignException
@@ -27,7 +26,7 @@ class OAuthServiceTest :
             context("유효한 토큰인 경우") {
                 it("카카오 사용자 정보를 반환한다") {
                     val token = "valid_kakao_token"
-                    val expected = KaKaoClientResult("kakaoId123", "test@kakao.com", "카카오유저", "닉네임")
+                    val expected = AuthFixture.kaKaoClientResult
 
                     every { kaKaoClient.getUserInfo(token) } returns expected
 
@@ -77,7 +76,7 @@ class OAuthServiceTest :
             context("빈 토큰인 경우") {
                 it("카카오 클라이언트를 호출한다") {
                     val token = ""
-                    val expected = KaKaoClientResult("id", "email@test.com", "name", "nickname")
+                    val expected = AuthFixture.kaKaoClientResult
 
                     every { kaKaoClient.getUserInfo(token) } returns expected
 
@@ -92,7 +91,7 @@ class OAuthServiceTest :
             context("유효한 토큰인 경우") {
                 it("애플 사용자 정보를 반환한다") {
                     val token = "valid_apple_token"
-                    val expected = AppleClientResult("appleId123", "test@apple.com")
+                    val expected = AuthFixture.appleClientResult
 
                     every { appleClient.verify(token) } returns true
                     every { appleClient.getUserInfo(token) } returns expected

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/user/UserFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/user/UserFacadeTest.kt
@@ -2,11 +2,18 @@ package com.sseudam.application.user
 
 import com.sseudam.DevelopTest
 import com.sseudam.auth.AuthenticationService
+import com.sseudam.fixture.user.UserFixture
 import com.sseudam.pet.UserPetService
 import com.sseudam.user.UserFacade
 import com.sseudam.user.UserService
+import com.sseudam.user.command.UserWithdrawalCommand
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 
 @DevelopTest
 class UserFacadeTest :
@@ -20,4 +27,111 @@ class UserFacadeTest :
                 authenticationService = authenticationService,
                 userPetService = userPetService,
             )
+        describe("사용자 탈퇴") {
+            context("유효한 사용자인 경우") {
+                it("트랜잭션 내에서 펫 삭제, 사용자 삭제, 인증 정보 삭제를 순차적으로 실행한다") {
+                    val user = UserFixture.user
+                    val withdrawalCommand = UserWithdrawalCommand(user)
+
+                    every { userPetService.deleteByUser(user.id) } just Runs
+                    every { userService.deleteUser(withdrawalCommand) } just Runs
+                    every { authenticationService.withdrawUser(user.key) } just Runs
+
+                    userFacade.withdrawalUser(user)
+
+                    verify { userPetService.deleteByUser(user.id) }
+                    verify { userService.deleteUser(withdrawalCommand) }
+                    verify { authenticationService.withdrawUser(user.key) }
+                }
+            }
+
+            context("펫 삭제 중 예외가 발생한 경우") {
+                it("예외가 발생하고 트랜잭션이 롤백된다") {
+                    val user = UserFixture.user
+
+                    every { userPetService.deleteByUser(user.id) } throws RuntimeException("펫 삭제 실패")
+
+                    try {
+                        userFacade.withdrawalUser(user)
+                    } catch (e: RuntimeException) {
+                        e.message shouldBe "펫 삭제 실패"
+                    }
+
+                    verify { userPetService.deleteByUser(user.id) }
+                }
+            }
+
+            context("사용자 삭제 중 예외가 발생한 경우") {
+                it("예외가 발생하고 트랜잭션이 롤백된다") {
+                    val user = UserFixture.user
+                    val withdrawalCommand = UserWithdrawalCommand(user)
+
+                    every { userPetService.deleteByUser(user.id) } just Runs
+                    every { userService.deleteUser(withdrawalCommand) } throws RuntimeException("사용자 삭제 실패")
+
+                    try {
+                        userFacade.withdrawalUser(user)
+                    } catch (e: RuntimeException) {
+                        e.message shouldBe "사용자 삭제 실패"
+                    }
+
+                    verify { userPetService.deleteByUser(user.id) }
+                    verify { userService.deleteUser(withdrawalCommand) }
+                }
+            }
+
+            context("인증 정보 삭제 중 예외가 발생한 경우") {
+                it("예외가 발생하고 트랜잭션이 롤백된다") {
+                    val user = UserFixture.user
+                    val withdrawalCommand = UserWithdrawalCommand(user)
+
+                    every { userPetService.deleteByUser(user.id) } just Runs
+                    every { userService.deleteUser(withdrawalCommand) } just Runs
+                    every { authenticationService.withdrawUser(user.key) } throws RuntimeException("인증 정보 삭제 실패")
+
+                    try {
+                        userFacade.withdrawalUser(user)
+                    } catch (e: RuntimeException) {
+                        e.message shouldBe "인증 정보 삭제 실패"
+                    }
+
+                    verify { userPetService.deleteByUser(user.id) }
+                    verify { userService.deleteUser(withdrawalCommand) }
+                    verify { authenticationService.withdrawUser(user.key) }
+                }
+            }
+
+            context("펫이 없는 사용자인 경우") {
+                it("펫 삭제는 실행되지만 에러 없이 사용자 삭제와 인증 정보 삭제를 진행한다") {
+                    val user = UserFixture.user
+                    val withdrawalCommand = UserWithdrawalCommand(user)
+
+                    every { userPetService.deleteByUser(user.id) } just Runs
+                    every { userService.deleteUser(withdrawalCommand) } just Runs
+                    every { authenticationService.withdrawUser(user.key) } just Runs
+
+                    userFacade.withdrawalUser(user)
+
+                    verify { userPetService.deleteByUser(user.id) }
+                    verify { userService.deleteUser(withdrawalCommand) }
+                    verify { authenticationService.withdrawUser(user.key) }
+                }
+            }
+
+            context("작업 순서 검증") {
+                it("펫 삭제 -> 사용자 삭제 -> 인증 정보 삭제 순서로 실행된다") {
+                    val user = UserFixture.user
+                    val withdrawalCommand = UserWithdrawalCommand(user)
+                    val callOrder = mutableListOf<String>()
+
+                    every { userPetService.deleteByUser(user.id) } answers { callOrder.add("pet") }
+                    every { userService.deleteUser(withdrawalCommand) } answers { callOrder.add("user") }
+                    every { authenticationService.withdrawUser(user.key) } answers { callOrder.add("auth") }
+
+                    userFacade.withdrawalUser(user)
+
+                    callOrder shouldBe listOf("pet", "user", "auth")
+                }
+            }
+        }
     })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/user/UserFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/user/UserFacadeTest.kt
@@ -1,0 +1,23 @@
+package com.sseudam.application.user
+
+import com.sseudam.DevelopTest
+import com.sseudam.auth.AuthenticationService
+import com.sseudam.pet.UserPetService
+import com.sseudam.user.UserFacade
+import com.sseudam.user.UserService
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.mockk
+
+@DevelopTest
+class UserFacadeTest :
+    DescribeSpec({
+        val userService: UserService = mockk()
+        val authenticationService: AuthenticationService = mockk()
+        val userPetService: UserPetService = mockk()
+        val userFacade =
+            UserFacade(
+                userService = userService,
+                authenticationService = authenticationService,
+                userPetService = userPetService,
+            )
+    })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/user/UserServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/user/UserServiceTest.kt
@@ -1,0 +1,266 @@
+package com.sseudam.application.user
+
+import com.sseudam.DevelopTest
+import com.sseudam.fixture.common.PageFixture
+import com.sseudam.fixture.user.UserFixture
+import com.sseudam.support.page.Page
+import com.sseudam.user.UserProfile
+import com.sseudam.user.UserService
+import com.sseudam.user.command.UserCommand
+import com.sseudam.user.component.UserAppender
+import com.sseudam.user.component.UserDeleter
+import com.sseudam.user.component.UserReader
+import com.sseudam.user.component.UserUpdater
+import com.sseudam.user.component.UserValidator
+import com.sseudam.user.event.UserSignUpEvent
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+
+@DevelopTest
+class UserServiceTest :
+    DescribeSpec({
+        val userAppender: UserAppender = mockk()
+        val userReader: UserReader = mockk()
+        val userUpdater: UserUpdater = mockk()
+        val userDeleter: UserDeleter = mockk()
+        val userValidator: UserValidator = mockk()
+        val applicationEventPublisher: ApplicationEventPublisher = mockk()
+        val userService =
+            UserService(
+                userAppender = userAppender,
+                userReader = userReader,
+                userUpdater = userUpdater,
+                userDeleter = userDeleter,
+                userValidator = userValidator,
+                applicationEventPublisher = applicationEventPublisher,
+            )
+
+        describe("사용자 생성") {
+            context("유효한 사용자 정보인 경우") {
+                it("사용자를 생성하고 반환한다") {
+                    val userCommand = UserFixture.userCommand
+                    val user = UserFixture.user
+
+                    every { userValidator.verifyEmail(userCommand.email) } just Runs
+                    every { userAppender.create(userCommand) } returns user
+
+                    val result = userService.create(userCommand)
+
+                    result shouldBe user
+                    verify { userValidator.verifyEmail(userCommand.email) }
+                    verify { userAppender.create(userCommand) }
+                }
+            }
+        }
+
+        describe("소셜 회원가입") {
+            context("주소 정보가 있는 경우") {
+                it("이름과 주소를 업데이트하고 이벤트를 발행한다") {
+                    val socialUser = UserFixture.socialUser
+                    val userCommand = UserFixture.userCommand
+                    val userProfile = UserFixture.userProfile
+
+                    every { userValidator.verifyNickname(userCommand.name) } just Runs
+                    every { userUpdater.updateName(socialUser.key, userCommand.name) } returns userProfile
+                    every { userUpdater.updateAddress(socialUser.key, userCommand.address!!) } returns userProfile
+                    every { applicationEventPublisher.publishEvent(any<UserSignUpEvent>()) } just Runs
+
+                    userService.socialSignUp(socialUser, userCommand)
+
+                    verify { userUpdater.updateName(socialUser.key, userCommand.name) }
+                    verify { userUpdater.updateAddress(socialUser.key, userCommand.address!!) }
+                    verify { applicationEventPublisher.publishEvent(UserSignUpEvent(socialUser.id)) }
+                }
+            }
+
+            context("주소 정보가 없는 경우") {
+                it("이름만 업데이트하고 이벤트를 발행한다") {
+                    val socialUser = UserFixture.socialUser
+                    val userCommand: UserCommand = UserFixture.userCommand
+                    val userProfile = UserFixture.userProfile
+                    val name = "홍길동"
+
+                    every { userValidator.verifyNickname(name) } just Runs
+                    every { userUpdater.updateName(socialUser.key, name) } returns userProfile
+                    every { applicationEventPublisher.publishEvent(any<UserSignUpEvent>()) } just Runs
+
+                    userService.socialSignUp(socialUser, userCommand)
+
+                    verify { userValidator.verifyNickname(name) }
+                    verify { userUpdater.updateName(socialUser.key, name) }
+                    verify(exactly = 0) { userUpdater.updateAddress(userProfile.key, userProfile.address) }
+                    verify { applicationEventPublisher.publishEvent(UserSignUpEvent(socialUser.id)) }
+                }
+            }
+        }
+
+        describe("프로필 조회") {
+            context("존재하는 사용자인 경우") {
+                it("사용자 프로필을 반환한다") {
+                    val userId = 1L
+                    val userProfile = UserFixture.userProfile
+
+                    every { userReader.readUserProfile(userId) } returns userProfile
+
+                    val result = userService.getProfile(userId)
+
+                    result shouldBe userProfile
+                    verify { userReader.readUserProfile(userId) }
+                }
+            }
+
+            context("존재하지 않는 사용자인 경우") {
+                it("null을 반환한다") {
+                    val userId = 999L
+
+                    every { userReader.readUserProfile(userId) } returns null
+
+                    val result = userService.getProfile(userId)
+
+                    result shouldBe null
+                }
+            }
+        }
+
+        describe("이메일로 소셜 사용자 조회") {
+            context("존재하는 이메일인 경우") {
+                it("소셜 사용자를 반환한다") {
+                    val email = "test@example.com"
+                    val socialUser = UserFixture.socialUser
+
+                    every { userReader.readUserByEmail(email) } returns socialUser
+
+                    val result = userService.getSocialUserByEmail(email)
+
+                    result shouldBe socialUser
+                }
+            }
+
+            context("존재하지 않는 이메일인 경우") {
+                it("null을 반환한다") {
+                    val email = "notfound@example.com"
+
+                    every { userReader.readUserByEmail(email) } returns null
+
+                    val result = userService.getSocialUserByEmail(email)
+
+                    result shouldBe null
+                }
+            }
+        }
+
+        describe("닉네임 업데이트") {
+            context("유효한 닉네임인 경우") {
+                it("닉네임을 업데이트하고 프로필을 반환한다") {
+                    val userKey = "userKey123"
+                    val updateCommand = UserFixture.updateNicknameCommand
+                    val userProfile = UserFixture.userProfile
+
+                    every { userValidator.verifyNickname(updateCommand.nickname) } just Runs
+                    every { userUpdater.updateNickname(userKey, updateCommand) } returns userProfile
+
+                    val result = userService.updateNickname(userKey, updateCommand)
+
+                    result shouldBe userProfile
+                    verify { userValidator.verifyNickname(updateCommand.nickname) }
+                    verify { userUpdater.updateNickname(userKey, updateCommand) }
+                }
+            }
+        }
+
+        describe("이메일 검증") {
+            context("사용 가능한 이메일인 경우") {
+                it("예외를 던지지 않는다") {
+                    val email = "available@example.com"
+
+                    every { userValidator.verifyEmail(email) } just Runs
+
+                    userService.checkEmail(email)
+
+                    verify { userValidator.verifyEmail(email) }
+                }
+            }
+        }
+
+        describe("닉네임 검증") {
+            context("유효한 닉네임인 경우") {
+                it("true를 반환한다") {
+                    val nickname = "유효한닉네임"
+
+                    every { userValidator.verifyNickname(nickname) } just Runs
+
+                    val result = userService.validateNickname(nickname)
+
+                    result shouldBe true
+                    verify { userValidator.verifyNickname(nickname) }
+                }
+            }
+        }
+
+        describe("사용자 탈퇴") {
+            context("유효한 사용자인 경우") {
+                it("사용자를 삭제한다") {
+                    val withdrawalCommand = UserFixture.userWithdrawalCommand
+
+                    every { userDeleter.deleteUser(withdrawalCommand.user.key) } just Runs
+
+                    userService.deleteUser(withdrawalCommand)
+
+                    verify { userDeleter.deleteUser(withdrawalCommand.user.key) }
+                }
+            }
+        }
+
+        describe("페이징 조회") {
+            context("페이지 요청이 있는 경우") {
+                it("페이징된 사용자 프로필을 반환한다") {
+                    val offsetPageRequest = PageFixture.offsetPageRequest
+                    val userProfile = UserFixture.userProfile
+                    val page = Page(listOf(userProfile), 1)
+
+                    every { userReader.readAllBy(offsetPageRequest) } returns page
+
+                    val result = userService.findUserProfileBy(offsetPageRequest)
+
+                    result shouldBe page
+                    verify { userReader.readAllBy(offsetPageRequest) }
+                }
+            }
+        }
+
+        describe("여러 사용자 조회") {
+            context("사용자 ID 목록이 주어진 경우") {
+                it("해당하는 사용자 프로필 목록을 반환한다") {
+                    val userIds = listOf(1L, 2L, 3L)
+                    val userProfile = UserFixture.userProfile
+                    val userProfiles = listOf(userProfile)
+
+                    every { userReader.readAllByUserIds(userIds) } returns userProfiles
+
+                    val result = userService.findAllBy(userIds)
+
+                    result shouldBe userProfiles
+                    verify { userReader.readAllByUserIds(userIds) }
+                }
+            }
+
+            context("빈 ID 목록인 경우") {
+                it("빈 목록을 반환한다") {
+                    val userIds = emptyList<Long>()
+                    val userProfiles = emptyList<UserProfile>()
+
+                    every { userReader.readAllByUserIds(userIds) } returns userProfiles
+
+                    val result = userService.findAllBy(userIds)
+
+                    result shouldBe userProfiles
+                }
+            }
+        }
+    })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/auth/AuthFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/auth/AuthFixture.kt
@@ -1,0 +1,80 @@
+package com.sseudam.fixture.auth
+
+import com.navercorp.fixturemonkey.kotlin.setExp
+import com.sseudam.auth.AuthorityType
+import com.sseudam.auth.Token
+import com.sseudam.auth.command.CredentialSocialCommand
+import com.sseudam.auth.command.CredentialSseudamCommand
+import com.sseudam.auth.dto.GrantedAuthority
+import com.sseudam.client.oauth.AppleClientResult
+import com.sseudam.client.oauth.KaKaoClientResult
+import com.sseudam.test.helper.fixtureBuilder
+import com.sseudam.user.SocialType
+import com.sseudam.user.SocialUser
+
+object AuthFixture {
+    val token =
+        fixtureBuilder<Token> {
+            setExp(Token::accessToken, "accessToken")
+            setExp(Token::refreshToken, "refreshToken")
+        }
+
+    val credentialSseudamCommand =
+        fixtureBuilder<CredentialSseudamCommand> {
+            setExp(CredentialSseudamCommand::loginId, "test@test.com")
+            setExp(CredentialSseudamCommand::password, "password")
+        }
+
+    val credentialSocialCommand =
+        fixtureBuilder<CredentialSocialCommand> {
+            setExp(CredentialSocialCommand::email, "test@kakao.com")
+            setExp(CredentialSocialCommand::name, "카카오유저")
+            setExp(CredentialSocialCommand::socialId, "socialId123")
+            setExp(CredentialSocialCommand::socialType, SocialType.KAKAO)
+        }
+
+    val credentialNewSocialCommand =
+        fixtureBuilder<CredentialSocialCommand> {
+            setExp(CredentialSocialCommand::email, "test@apple.com")
+            setExp(CredentialSocialCommand::name, "")
+            setExp(CredentialSocialCommand::socialId, "socialId123")
+            setExp(CredentialSocialCommand::socialType, SocialType.APPLE)
+        }
+
+    val socialUser =
+        fixtureBuilder<SocialUser> {
+            setExp(SocialUser::id, 1L)
+            setExp(SocialUser::key, "userKey")
+            setExp(SocialUser::name, "카카오유저")
+            setExp(SocialUser::socialId, "socialId123")
+            setExp(SocialUser::socialType, SocialType.KAKAO)
+        }
+
+    val socialNewUser =
+        fixtureBuilder<SocialUser> {
+            setExp(SocialUser::id, 1L)
+            setExp(SocialUser::key, "userKey")
+            setExp(SocialUser::name, "")
+            setExp(SocialUser::socialId, "socialId123")
+            setExp(SocialUser::socialType, SocialType.APPLE)
+        }
+
+    val grantedAuthority =
+        fixtureBuilder<GrantedAuthority> {
+            setExp(GrantedAuthority::authorityType, AuthorityType.ADMIN)
+        }
+
+    val kaKaoClientResult =
+        fixtureBuilder<KaKaoClientResult> {
+            setExp(KaKaoClientResult::id, "kakaoId123")
+            setExp(KaKaoClientResult::email, "test@kakao.com")
+            setExp(KaKaoClientResult::name, "카카오유저")
+            setExp(KaKaoClientResult::nickname, "카카오닉네임")
+        }
+
+    val appleClientResult =
+        fixtureBuilder<AppleClientResult> {
+            setExp(AppleClientResult::id, "appleId123")
+            setExp(AppleClientResult::email, "test@apple.com")
+        }
+}

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/common/AddressFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/common/AddressFixture.kt
@@ -1,0 +1,13 @@
+package com.sseudam.fixture.common
+
+import com.navercorp.fixturemonkey.kotlin.setExp
+import com.sseudam.common.Address
+import com.sseudam.test.helper.fixtureBuilder
+
+object AddressFixture {
+    val addressFixture =
+        fixtureBuilder<Address> {
+            setExp(Address::city, "구로구")
+            setExp(Address::site, "서울특별시 구로구 가마산로 250")
+        }
+}

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/common/PageFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/common/PageFixture.kt
@@ -1,0 +1,13 @@
+package com.sseudam.fixture.common
+
+import com.navercorp.fixturemonkey.kotlin.setExp
+import com.sseudam.support.cursor.OffsetPageRequest
+import com.sseudam.test.helper.fixtureBuilder
+
+object PageFixture {
+    val offsetPageRequest =
+        fixtureBuilder<OffsetPageRequest> {
+            setExp(OffsetPageRequest::page, 0)
+            setExp(OffsetPageRequest::size, 10)
+        }
+}

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/user/UserFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/user/UserFixture.kt
@@ -1,0 +1,27 @@
+package com.sseudam.fixture.user
+
+import com.navercorp.fixturemonkey.kotlin.setExp
+import com.sseudam.fixture.common.AddressFixture
+import com.sseudam.test.helper.fixtureBuilder
+import com.sseudam.user.User
+import com.sseudam.user.UserProfile
+import java.time.LocalDateTime
+
+object UserFixture {
+    val user =
+        fixtureBuilder<User> {
+            setExp(User::id, 1L)
+            setExp(User::key, "20251003_UK_d69fc385032246949285908cf6588a41")
+        }
+
+    val userProfile =
+        fixtureBuilder<UserProfile> {
+            setExp(UserProfile::id, 1L)
+            setExp(UserProfile::key, "20251003_UK_d69fc385032246949285908cf6588a41")
+            setExp(UserProfile::email, "test@test.com")
+            setExp(UserProfile::name, "Test User")
+            setExp(UserProfile::nickname, "TestNickname")
+            setExp(UserProfile::address, AddressFixture.addressFixture)
+            setExp(UserProfile::createdAt, LocalDateTime.now())
+        }
+}

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/user/UserFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/user/UserFixture.kt
@@ -3,8 +3,13 @@ package com.sseudam.fixture.user
 import com.navercorp.fixturemonkey.kotlin.setExp
 import com.sseudam.fixture.common.AddressFixture
 import com.sseudam.test.helper.fixtureBuilder
+import com.sseudam.user.SocialType
+import com.sseudam.user.SocialUser
 import com.sseudam.user.User
 import com.sseudam.user.UserProfile
+import com.sseudam.user.command.UpdateNicknameCommand
+import com.sseudam.user.command.UserCommand
+import com.sseudam.user.command.UserWithdrawalCommand
 import java.time.LocalDateTime
 
 object UserFixture {
@@ -23,5 +28,31 @@ object UserFixture {
             setExp(UserProfile::nickname, "TestNickname")
             setExp(UserProfile::address, AddressFixture.addressFixture)
             setExp(UserProfile::createdAt, LocalDateTime.now())
+        }
+
+    val userCommand =
+        fixtureBuilder<UserCommand> {
+            setExp(UserCommand::email, "test@example.com")
+            setExp(UserCommand::name, "홍길동")
+            setExp(UserCommand::address, AddressFixture.addressFixture)
+        }
+
+    val socialUser =
+        fixtureBuilder<SocialUser> {
+            setExp(SocialUser::id, 1L)
+            setExp(SocialUser::key, "userKey123")
+            setExp(SocialUser::name, "카카오유저")
+            setExp(SocialUser::socialId, "socialId123")
+            setExp(SocialUser::socialType, SocialType.KAKAO)
+        }
+
+    val updateNicknameCommand =
+        fixtureBuilder<UpdateNicknameCommand> {
+            setExp(UpdateNicknameCommand::nickname, "새닉네임")
+        }
+
+    val userWithdrawalCommand =
+        fixtureBuilder<UserWithdrawalCommand> {
+            setExp(UserWithdrawalCommand::user, user)
         }
 }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/user/UserControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/user/UserControllerTest.kt
@@ -1,0 +1,227 @@
+package com.sseudam.presentation.v1.user
+
+import com.sseudam.RestDocsTest
+import com.sseudam.config.UserArgumentResolver
+import com.sseudam.docs.RestDocsTestSuite
+import com.sseudam.docs.support.Authorization
+import com.sseudam.docs.support.BOOLEAN
+import com.sseudam.docs.support.DocsTag
+import com.sseudam.docs.support.MockMvcExtensions.makeDocument
+import com.sseudam.docs.support.NUMBER
+import com.sseudam.docs.support.RestDocsUtils.headers
+import com.sseudam.docs.support.RestDocsUtils.requestBody
+import com.sseudam.docs.support.RestDocsUtils.responseBody
+import com.sseudam.docs.support.STRING
+import com.sseudam.docs.support.headerType
+import com.sseudam.docs.support.type
+import com.sseudam.fixture.user.UserFixture
+import com.sseudam.presentation.v1.user.request.NicknameRequest
+import com.sseudam.presentation.v1.user.request.UserMobileDeviceRequest
+import com.sseudam.user.User
+import com.sseudam.user.UserDeviceService
+import com.sseudam.user.UserFacade
+import com.sseudam.user.UserService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.restassured.http.ContentType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.restdocs.RestDocumentationContextProvider
+import java.util.UUID
+
+@RestDocsTest
+class UserControllerTest : RestDocsTestSuite() {
+    private lateinit var userController: UserController
+    private lateinit var userService: UserService
+    private lateinit var userFacade: UserFacade
+    private lateinit var userDeviceService: UserDeviceService
+    private lateinit var userArgumentResolver: UserArgumentResolver
+
+    @BeforeEach
+    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+        userArgumentResolver = mockk()
+        userService = mockk()
+        userFacade = mockk()
+        userDeviceService = mockk()
+        userController =
+            UserController(
+                userService = userService,
+                userFacade = userFacade,
+                userDeviceService = userDeviceService,
+            )
+        mockMvcSpec = mockController(userController, userArgumentResolver)
+        every { userArgumentResolver.supportsParameter(any()) } returns true
+        every { userArgumentResolver.resolveArgument(any(), any(), any(), any()) } returns
+            User(
+                id = 1L,
+                key = UUID.randomUUID().toString(),
+            )
+    }
+
+    @DisplayName("내 정보 조회 - 200")
+    @Test
+    fun t1() {
+        every { userService.getProfile(any()) } returns UserFixture.userProfile
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .contentType(ContentType.JSON)
+                .get("/api/v1/users/me")
+                .then()
+                .status(HttpStatus.OK)
+
+        response.makeDocument(
+            "내 정보 조회",
+            DocsTag.USER,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "UserProfileResponse",
+            responseBody(
+                "userId" type NUMBER means "사용자 ID",
+                "email" type STRING means "이메일",
+                "name" type STRING means "이름",
+                "nickname" type STRING means "닉네임",
+            ),
+        )
+    }
+
+    @DisplayName("회원탈퇴 - 200")
+    @Test
+    fun t2() {
+        every { userFacade.withdrawalUser(any()) } returns Unit
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .delete("/api/v1/users")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "회원탈퇴",
+            DocsTag.USER,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "UserWithdrawalResponse",
+            responseBody(
+                "message" type STRING means "탈퇴 완료 메시지",
+            ),
+        )
+    }
+
+    @DisplayName("닉네임 수정 - 200")
+    @Test
+    fun t3() {
+        val request = NicknameRequest("newNickname")
+
+        every { userService.updateNickname(any(), any()) } returns UserFixture.userProfile
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .contentType(ContentType.JSON)
+                .body(request)
+                .put("/api/v1/users/nickname")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "닉네임 수정",
+            DocsTag.USER,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "NicknameRequest",
+            "UserProfileResponse",
+            requestBody(
+                "nickname" type STRING means "새로운 닉네임" example "newNickname",
+            ),
+            responseBody(
+                "userId" type NUMBER means "사용자 ID",
+                "email" type STRING means "이메일",
+                "name" type STRING means "이름",
+                "nickname" type STRING means "수정된 닉네임",
+            ),
+        )
+    }
+
+    @DisplayName("닉네임 유효성 검사 - 200")
+    @Test
+    fun t4() {
+        val request = NicknameRequest("validNickname")
+
+        every { userService.validateNickname(any()) } returns true
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/users/nickname/validate")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "닉네임 유효성 검사",
+            DocsTag.USER,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "NicknameRequest",
+            "IsValidateNicknameResponse",
+            requestBody(
+                "nickname" type STRING means "검증할 닉네임" example "validNickname",
+            ),
+            responseBody(
+                "isValid" type BOOLEAN means "유효성 검사 결과",
+                "message" type STRING means "검사 결과 메시지",
+            ),
+        )
+    }
+
+    @DisplayName("FCM 토큰 추가 및 갱신 - 200")
+    @Test
+    fun t5() {
+        val request = UserMobileDeviceRequest("fcmToken123")
+
+        every { userDeviceService.append(any()) } just Runs
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .header("X-DEVICE-ID", "device123")
+                .contentType(ContentType.JSON)
+                .body(request)
+                .put("/api/v1/users/fcm-token")
+                .then()
+                .status(HttpStatus.OK)
+                .contentType(ContentType.JSON)
+
+        response.makeDocument(
+            "FCM 토큰 추가",
+            DocsTag.USER,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "UserMobileDeviceRequest",
+            "UserMobileDeviceResponse",
+            requestBody(
+                "fcmToken" type STRING means "FCM 토큰" example "fcmToken123",
+            ),
+            responseBody(
+                "message" type STRING means "등록 완료 메시지",
+            ),
+        )
+    }
+}

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/user/UserFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/user/UserFacade.kt
@@ -2,9 +2,9 @@ package com.sseudam.user
 
 import com.sseudam.auth.AuthenticationService
 import com.sseudam.pet.UserPetService
-import com.sseudam.support.tx.Tx
 import com.sseudam.user.command.UserWithdrawalCommand
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserFacade(
@@ -12,14 +12,14 @@ class UserFacade(
     private val authenticationService: AuthenticationService,
     private val userPetService: UserPetService,
 ) {
-    fun withdrawalUser(user: User) =
-        Tx.writeable {
-            userPetService.deleteByUser(user.id)
-            userService.deleteUser(
-                UserWithdrawalCommand(
-                    user = user,
-                ),
-            )
-            authenticationService.withdrawUser(user.key)
-        }
+    @Transactional
+    fun withdrawalUser(user: User) {
+        userPetService.deleteByUser(user.id)
+        userService.deleteUser(
+            UserWithdrawalCommand(
+                user = user,
+            ),
+        )
+        authenticationService.withdrawUser(user.key)
+    }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/user/UserService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/user/UserService.kt
@@ -3,7 +3,6 @@ package com.sseudam.user
 import com.sseudam.common.Address
 import com.sseudam.support.cursor.OffsetPageRequest
 import com.sseudam.support.page.Page
-import com.sseudam.support.tx.Tx
 import com.sseudam.user.command.UpdateNicknameCommand
 import com.sseudam.user.command.UserCommand
 import com.sseudam.user.command.UserWithdrawalCommand
@@ -15,6 +14,7 @@ import com.sseudam.user.component.UserValidator
 import com.sseudam.user.event.UserSignUpEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserService(
@@ -25,17 +25,18 @@ class UserService(
     private val userValidator: UserValidator,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
-    fun create(userCommand: UserCommand): User =
-        Tx.writeable {
-            userValidator.verifyEmail(userCommand.email)
-            val createdUser = userAppender.create(userCommand)
-            return@writeable createdUser
-        }
+    @Transactional
+    fun create(userCommand: UserCommand): User {
+        userValidator.verifyEmail(userCommand.email)
+        val createdUser = userAppender.create(userCommand)
+        return createdUser
+    }
 
+    @Transactional
     fun socialSignUp(
         socialUser: SocialUser,
         userCommand: UserCommand,
-    ) = Tx.writeable {
+    ) {
         updateName(socialUser.key, userCommand.name)
         userCommand.address?.let { address ->
             updateAddress(socialUser.key, address)

--- a/sseudam-tests/api-docs/src/main/kotlin/com/sseudam/docs/RestDocsTestSuite.kt
+++ b/sseudam-tests/api-docs/src/main/kotlin/com/sseudam/docs/RestDocsTestSuite.kt
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
 import org.springframework.web.filter.CharacterEncodingFilter
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
 
 @Tag("restdocs")
 @ExtendWith(RestDocumentationExtension::class)
@@ -36,6 +37,14 @@ abstract class RestDocsTestSuite {
         return RestAssuredMockMvc.given().mockMvc(mockMvc)
     }
 
+    protected fun mockController(
+        controller: Any,
+        argumentResolver: HandlerMethodArgumentResolver,
+    ): MockMvcRequestSpecification {
+        val mockMvc = createMockMvc(controller, argumentResolver)
+        return RestAssuredMockMvc.given().mockMvc(mockMvc)
+    }
+
     private fun createMockMvc(controller: Any): MockMvc {
         val converter = MappingJackson2HttpMessageConverter(objectMapper())
 
@@ -44,6 +53,20 @@ abstract class RestDocsTestSuite {
             .addFilter<StandaloneMockMvcBuilder>(CharacterEncodingFilter("UTF-8", true))
             .apply<StandaloneMockMvcBuilder>(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
             .setMessageConverters(converter)
+            .build()
+    }
+
+    private fun createMockMvc(
+        controller: Any,
+        argumentResolver: HandlerMethodArgumentResolver,
+    ): MockMvc {
+        val converter = MappingJackson2HttpMessageConverter(objectMapper())
+        return MockMvcBuilders
+            .standaloneSetup(controller)
+            .addFilter<StandaloneMockMvcBuilder>(CharacterEncodingFilter("UTF-8", true))
+            .apply<StandaloneMockMvcBuilder>(MockMvcRestDocumentation.documentationConfiguration(restDocumentation))
+            .setMessageConverters(converter)
+            .setCustomArgumentResolvers(argumentResolver)
             .build()
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #198 

## 📌 작업 내용 및 특이 사항

- 2ab37844109cd65e30c94a4f42d54f146f33feee: UserController RestDocsTest
- 3a8385a582b37a339bc52b1a68e8e09e6e6e42d5: AuthFixture로 개선
- d721a738641cdd4c5f9804f50228b4ddc70ae790: User 비즈니스 로직 테스트 코드

## 📝 참고

- 현재 Tx 확장함수에서 TxAdvice를 lateinit하니 테스트 코드 오류 발생으로 Transactional 어노테이션으로 변경

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Enhanced API docs for user endpoints: profile retrieval, withdrawal, nickname update/validation, and FCM token management.
* Tests
  * Added comprehensive tests for authentication, user services, and user controller.
  * Introduced reusable test fixtures and improved test configuration for stability and clarity.
* Refactor
  * Standardized transactional handling across user operations.
  * Simplified self-profile endpoint parameter handling without changing behavior or responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->