### PR TITLE
[Test] History Domain Test Code

### DIFF
--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/history/HistoryFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/history/HistoryFacadeTest.kt
@@ -19,112 +19,115 @@ import io.mockk.mockk
 import io.mockk.verify
 
 @DevelopTest
-class HistoryFacadeTest : DescribeSpec({
-    val reportService: ReportService = mockk()
-    val suggestionService: SuggestionService = mockk()
-    val historyFacade = HistoryFacade(reportService, suggestionService)
+class HistoryFacadeTest :
+    DescribeSpec({
+        val reportService: ReportService = mockk()
+        val suggestionService: SuggestionService = mockk()
+        val historyFacade = HistoryFacade(reportService, suggestionService)
 
-    describe("내역 조회") {
-        context("신고와 제보 내역이 모두 있는 경우") {
-            it("모든 내역을 생성일자 내림차순으로 반환한다") {
-                val userId = 1L
-                val reports = listOf(ReportFixture.spotReportInfo)
-                val suggestions = listOf(SuggestionFixture.spotSuggestionInfo)
+        describe("내역 조회") {
+            context("신고와 제보 내역이 모두 있는 경우") {
+                it("모든 내역을 생성일자 내림차순으로 반환한다") {
+                    val userId = 1L
+                    val reports = listOf(ReportFixture.spotReportInfo)
+                    val suggestions = listOf(SuggestionFixture.spotSuggestionInfo)
 
-                every { reportService.findAllReportByUserId(userId) } returns reports
-                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
+                    every { reportService.findAllReportByUserId(userId) } returns reports
+                    every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
 
-                val result = historyFacade.findHistories(userId)
+                    val result = historyFacade.findHistories(userId)
 
-                result shouldHaveSize 2
-                result.any { it.actionType == SpotActionType.REPORT } shouldBe true
-                result.any { it.actionType == SpotActionType.SUGGESTION } shouldBe true
-                verify { reportService.findAllReportByUserId(userId) }
-                verify { suggestionService.findAllSpotSuggestionByUser(userId) }
+                    result shouldHaveSize 2
+                    result.any { it.actionType == SpotActionType.REPORT } shouldBe true
+                    result.any { it.actionType == SpotActionType.SUGGESTION } shouldBe true
+                    verify { reportService.findAllReportByUserId(userId) }
+                    verify { suggestionService.findAllSpotSuggestionByUser(userId) }
+                }
+            }
+
+            context("신고 내역만 있는 경우") {
+                it("신고 내역만 반환한다") {
+                    val userId = 1L
+                    val reports = listOf(ReportFixture.spotReportInfo)
+
+                    every { reportService.findAllReportByUserId(userId) } returns reports
+                    every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
+
+                    val result = historyFacade.findHistories(userId)
+
+                    result shouldHaveSize 1
+                    result.first().actionType shouldBe SpotActionType.REPORT
+                }
+            }
+
+            context("제보 내역만 있는 경우") {
+                it("제보 내역만 반환한다") {
+                    val userId = 1L
+                    val suggestions = listOf(SuggestionFixture.spotSuggestionInfo)
+
+                    every { reportService.findAllReportByUserId(userId) } returns emptyList()
+                    every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
+
+                    val result = historyFacade.findHistories(userId)
+
+                    result shouldHaveSize 1
+                    result.first().actionType shouldBe SpotActionType.SUGGESTION
+                }
+            }
+
+            context("내역이 없는 경우") {
+                it("빈 목록을 반환한다") {
+                    val userId = 999L
+
+                    every { reportService.findAllReportByUserId(userId) } returns emptyList()
+                    every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
+
+                    val result = historyFacade.findHistories(userId)
+
+                    result.shouldBeEmpty()
+                }
+            }
+
+            context("상태 변환이 올바른 경우") {
+                it("신고 상태가 내역 상태로 변환된다") {
+                    val userId = 1L
+                    val reports =
+                        listOf(
+                            ReportFixture.spotReportInfo.copy(status = ReportStatus.APPROVE),
+                            ReportFixture.spotReportInfo.copy(id = 2L, status = ReportStatus.REJECT),
+                            ReportFixture.spotReportInfo.copy(id = 3L, status = ReportStatus.WAITING),
+                        )
+
+                    every { reportService.findAllReportByUserId(userId) } returns reports
+                    every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
+
+                    val result = historyFacade.findHistories(userId)
+
+                    result shouldHaveSize 3
+                    result.count { it.status == HistoryStatus.APPROVE } shouldBe 1
+                    result.count { it.status == HistoryStatus.REJECT } shouldBe 1
+                    result.count { it.status == HistoryStatus.WAITING } shouldBe 1
+                }
+
+                it("제보 상태가 내역 상태로 변환된다") {
+                    val userId = 1L
+                    val suggestions =
+                        listOf(
+                            SuggestionFixture.spotSuggestionInfo.copy(status = SuggestionStatus.APPROVE),
+                            SuggestionFixture.spotSuggestionInfo.copy(id = 2L, status = SuggestionStatus.REJECT),
+                            SuggestionFixture.spotSuggestionInfo.copy(id = 3L, status = SuggestionStatus.WAITING),
+                        )
+
+                    every { reportService.findAllReportByUserId(userId) } returns emptyList()
+                    every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
+
+                    val result = historyFacade.findHistories(userId)
+
+                    result shouldHaveSize 3
+                    result.count { it.status == HistoryStatus.APPROVE } shouldBe 1
+                    result.count { it.status == HistoryStatus.REJECT } shouldBe 1
+                    result.count { it.status == HistoryStatus.WAITING } shouldBe 1
+                }
             }
         }
-
-        context("신고 내역만 있는 경우") {
-            it("신고 내역만 반환한다") {
-                val userId = 1L
-                val reports = listOf(ReportFixture.spotReportInfo)
-
-                every { reportService.findAllReportByUserId(userId) } returns reports
-                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
-
-                val result = historyFacade.findHistories(userId)
-
-                result shouldHaveSize 1
-                result.first().actionType shouldBe SpotActionType.REPORT
-            }
-        }
-
-        context("제보 내역만 있는 경우") {
-            it("제보 내역만 반환한다") {
-                val userId = 1L
-                val suggestions = listOf(SuggestionFixture.spotSuggestionInfo)
-
-                every { reportService.findAllReportByUserId(userId) } returns emptyList()
-                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
-
-                val result = historyFacade.findHistories(userId)
-
-                result shouldHaveSize 1
-                result.first().actionType shouldBe SpotActionType.SUGGESTION
-            }
-        }
-
-        context("내역이 없는 경우") {
-            it("빈 목록을 반환한다") {
-                val userId = 999L
-
-                every { reportService.findAllReportByUserId(userId) } returns emptyList()
-                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
-
-                val result = historyFacade.findHistories(userId)
-
-                result.shouldBeEmpty()
-            }
-        }
-
-        context("상태 변환이 올바른 경우") {
-            it("신고 상태가 내역 상태로 변환된다") {
-                val userId = 1L
-                val reports = listOf(
-                    ReportFixture.spotReportInfo.copy(status = ReportStatus.APPROVE),
-                    ReportFixture.spotReportInfo.copy(id = 2L, status = ReportStatus.REJECT),
-                    ReportFixture.spotReportInfo.copy(id = 3L, status = ReportStatus.WAITING),
-                )
-
-                every { reportService.findAllReportByUserId(userId) } returns reports
-                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
-
-                val result = historyFacade.findHistories(userId)
-
-                result shouldHaveSize 3
-                result.count { it.status == HistoryStatus.APPROVE } shouldBe 1
-                result.count { it.status == HistoryStatus.REJECT } shouldBe 1
-                result.count { it.status == HistoryStatus.WAITING } shouldBe 1
-            }
-
-            it("제보 상태가 내역 상태로 변환된다") {
-                val userId = 1L
-                val suggestions = listOf(
-                    SuggestionFixture.spotSuggestionInfo.copy(status = SuggestionStatus.APPROVE),
-                    SuggestionFixture.spotSuggestionInfo.copy(id = 2L, status = SuggestionStatus.REJECT),
-                    SuggestionFixture.spotSuggestionInfo.copy(id = 3L, status = SuggestionStatus.WAITING),
-                )
-
-                every { reportService.findAllReportByUserId(userId) } returns emptyList()
-                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
-
-                val result = historyFacade.findHistories(userId)
-
-                result shouldHaveSize 3
-                result.count { it.status == HistoryStatus.APPROVE } shouldBe 1
-                result.count { it.status == HistoryStatus.REJECT } shouldBe 1
-                result.count { it.status == HistoryStatus.WAITING } shouldBe 1
-            }
-        }
-    }
-})
+    })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/history/HistoryFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/history/HistoryFacadeTest.kt
@@ -1,0 +1,130 @@
+package com.sseudam.application.history
+
+import com.sseudam.DevelopTest
+import com.sseudam.fixture.report.ReportFixture
+import com.sseudam.fixture.suggestion.SuggestionFixture
+import com.sseudam.history.HistoryFacade
+import com.sseudam.history.dto.HistoryStatus
+import com.sseudam.history.dto.SpotActionType
+import com.sseudam.report.ReportService
+import com.sseudam.report.ReportStatus
+import com.sseudam.suggestion.SuggestionService
+import com.sseudam.suggestion.SuggestionStatus
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@DevelopTest
+class HistoryFacadeTest : DescribeSpec({
+    val reportService: ReportService = mockk()
+    val suggestionService: SuggestionService = mockk()
+    val historyFacade = HistoryFacade(reportService, suggestionService)
+
+    describe("내역 조회") {
+        context("신고와 제보 내역이 모두 있는 경우") {
+            it("모든 내역을 생성일자 내림차순으로 반환한다") {
+                val userId = 1L
+                val reports = listOf(ReportFixture.spotReportInfo)
+                val suggestions = listOf(SuggestionFixture.spotSuggestionInfo)
+
+                every { reportService.findAllReportByUserId(userId) } returns reports
+                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
+
+                val result = historyFacade.findHistories(userId)
+
+                result shouldHaveSize 2
+                result.any { it.actionType == SpotActionType.REPORT } shouldBe true
+                result.any { it.actionType == SpotActionType.SUGGESTION } shouldBe true
+                verify { reportService.findAllReportByUserId(userId) }
+                verify { suggestionService.findAllSpotSuggestionByUser(userId) }
+            }
+        }
+
+        context("신고 내역만 있는 경우") {
+            it("신고 내역만 반환한다") {
+                val userId = 1L
+                val reports = listOf(ReportFixture.spotReportInfo)
+
+                every { reportService.findAllReportByUserId(userId) } returns reports
+                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
+
+                val result = historyFacade.findHistories(userId)
+
+                result shouldHaveSize 1
+                result.first().actionType shouldBe SpotActionType.REPORT
+            }
+        }
+
+        context("제보 내역만 있는 경우") {
+            it("제보 내역만 반환한다") {
+                val userId = 1L
+                val suggestions = listOf(SuggestionFixture.spotSuggestionInfo)
+
+                every { reportService.findAllReportByUserId(userId) } returns emptyList()
+                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
+
+                val result = historyFacade.findHistories(userId)
+
+                result shouldHaveSize 1
+                result.first().actionType shouldBe SpotActionType.SUGGESTION
+            }
+        }
+
+        context("내역이 없는 경우") {
+            it("빈 목록을 반환한다") {
+                val userId = 999L
+
+                every { reportService.findAllReportByUserId(userId) } returns emptyList()
+                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
+
+                val result = historyFacade.findHistories(userId)
+
+                result.shouldBeEmpty()
+            }
+        }
+
+        context("상태 변환이 올바른 경우") {
+            it("신고 상태가 내역 상태로 변환된다") {
+                val userId = 1L
+                val reports = listOf(
+                    ReportFixture.spotReportInfo.copy(status = ReportStatus.APPROVE),
+                    ReportFixture.spotReportInfo.copy(id = 2L, status = ReportStatus.REJECT),
+                    ReportFixture.spotReportInfo.copy(id = 3L, status = ReportStatus.WAITING),
+                )
+
+                every { reportService.findAllReportByUserId(userId) } returns reports
+                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns emptyList()
+
+                val result = historyFacade.findHistories(userId)
+
+                result shouldHaveSize 3
+                result.count { it.status == HistoryStatus.APPROVE } shouldBe 1
+                result.count { it.status == HistoryStatus.REJECT } shouldBe 1
+                result.count { it.status == HistoryStatus.WAITING } shouldBe 1
+            }
+
+            it("제보 상태가 내역 상태로 변환된다") {
+                val userId = 1L
+                val suggestions = listOf(
+                    SuggestionFixture.spotSuggestionInfo.copy(status = SuggestionStatus.APPROVE),
+                    SuggestionFixture.spotSuggestionInfo.copy(id = 2L, status = SuggestionStatus.REJECT),
+                    SuggestionFixture.spotSuggestionInfo.copy(id = 3L, status = SuggestionStatus.WAITING),
+                )
+
+                every { reportService.findAllReportByUserId(userId) } returns emptyList()
+                every { suggestionService.findAllSpotSuggestionByUser(userId) } returns suggestions
+
+                val result = historyFacade.findHistories(userId)
+
+                result shouldHaveSize 3
+                result.count { it.status == HistoryStatus.APPROVE } shouldBe 1
+                result.count { it.status == HistoryStatus.REJECT } shouldBe 1
+                result.count { it.status == HistoryStatus.WAITING } shouldBe 1
+            }
+        }
+    }
+})

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/history/HistoryFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/history/HistoryFixture.kt
@@ -1,0 +1,46 @@
+package com.sseudam.fixture.history
+
+import com.navercorp.fixturemonkey.kotlin.setExp
+import com.sseudam.common.Address
+import com.sseudam.common.GeoJson
+import com.sseudam.history.dto.HistoryStatus
+import com.sseudam.history.dto.SpotActionType
+import com.sseudam.history.dto.SpotHistory
+import com.sseudam.test.helper.fixtureBuilder
+import com.sseudam.test.helper.fixtureBuilders
+import com.sseudam.trashspot.TrashType
+import net.jqwik.api.Arbitraries
+
+object HistoryFixture {
+    private val DEFAULT_ADDRESS = Address("강남구", "서울시 강남구 강남동 1-4")
+    private val DEFAULT_POINT = GeoJson.Point(listOf(126.977969, 37.566535))
+
+    val spotHistoryInfo =
+        fixtureBuilder<SpotHistory.Info> {
+            setExp(SpotHistory.Info::id, 1L)
+            setExp(SpotHistory.Info::spotId, 1L)
+            setExp(SpotHistory.Info::userId, 1L)
+            setExp(SpotHistory.Info::point, DEFAULT_POINT)
+            setExp(SpotHistory.Info::spotName, "테스트 쓰레기통")
+            setExp(SpotHistory.Info::address, DEFAULT_ADDRESS)
+            setExp(SpotHistory.Info::trashType, TrashType.GENERAL)
+            setExp(SpotHistory.Info::imageUrl, "https://example.com/image.jpg")
+            setExp(SpotHistory.Info::status, HistoryStatus.WAITING)
+            setExp(SpotHistory.Info::actionType, SpotActionType.REPORT)
+        }
+
+    val spotHistoryInfos =
+        fixtureBuilders<SpotHistory.Info>(
+            block = {
+                setExp(SpotHistory.Info::userId, 1L)
+                setExp(SpotHistory.Info::point, DEFAULT_POINT)
+                setExp(SpotHistory.Info::spotName, Arbitraries.strings().ofMinLength(1).ofMaxLength(50))
+                setExp(SpotHistory.Info::address, DEFAULT_ADDRESS)
+                setExp(SpotHistory.Info::trashType, Arbitraries.of(TrashType.entries))
+                setExp(SpotHistory.Info::imageUrl, Arbitraries.strings().ofMaxLength(255))
+                setExp(SpotHistory.Info::status, Arbitraries.of(HistoryStatus.entries))
+                setExp(SpotHistory.Info::actionType, Arbitraries.of(SpotActionType.entries))
+            },
+            size = 3,
+        )
+}

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/history/HistoryControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/history/HistoryControllerTest.kt
@@ -1,0 +1,94 @@
+package com.sseudam.presentation.v1.history
+
+import com.sseudam.RestDocsTest
+import com.sseudam.config.UserArgumentResolver
+import com.sseudam.docs.RestDocsTestSuite
+import com.sseudam.docs.support.ARRAY
+import com.sseudam.docs.support.Authorization
+import com.sseudam.docs.support.DocsTag
+import com.sseudam.docs.support.ENUM
+import com.sseudam.docs.support.MockMvcExtensions.makeDocument
+import com.sseudam.docs.support.NUMBER
+import com.sseudam.docs.support.OBJECT
+import com.sseudam.docs.support.RestDocsUtils.headers
+import com.sseudam.docs.support.RestDocsUtils.responseBody
+import com.sseudam.docs.support.STRING
+import com.sseudam.docs.support.headerType
+import com.sseudam.docs.support.type
+import com.sseudam.fixture.history.HistoryFixture
+import com.sseudam.history.HistoryFacade
+import com.sseudam.history.dto.HistoryStatus
+import com.sseudam.history.dto.SpotActionType
+import com.sseudam.trashspot.TrashType
+import com.sseudam.user.User
+import io.mockk.every
+import io.mockk.mockk
+import io.restassured.http.ContentType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.restdocs.RestDocumentationContextProvider
+import java.util.UUID
+
+@RestDocsTest
+class HistoryControllerTest : RestDocsTestSuite() {
+    private lateinit var historyController: HistoryController
+    private lateinit var historyFacade: HistoryFacade
+    private lateinit var userArgumentResolver: UserArgumentResolver
+
+    @BeforeEach
+    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+        historyFacade = mockk()
+        userArgumentResolver = mockk()
+        historyController = HistoryController(historyFacade)
+        mockMvcSpec = mockController(historyController, userArgumentResolver)
+        every { userArgumentResolver.supportsParameter(any()) } returns true
+        every { userArgumentResolver.resolveArgument(any(), any(), any(), any()) } returns
+            User(id = 1L, key = UUID.randomUUID().toString())
+    }
+
+    @DisplayName("내역 조회 - 200")
+    @Test
+    fun t1() {
+        val histories = HistoryFixture.spotHistoryInfos
+
+        every { historyFacade.findHistories(any()) } returns histories
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .contentType(ContentType.JSON)
+                .get("/api/v1/histories")
+                .then()
+                .status(HttpStatus.OK)
+
+        response.makeDocument(
+            "내역 조회",
+            DocsTag.HISTORY,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "HistoryAllResponse",
+            responseBody(
+                "list" type ARRAY means "내역 목록",
+                "list[].id" type NUMBER means "내역 ID" example "1",
+                "list[].spotId" type NUMBER means "장소 ID" example "1" isOptional true,
+                "list[].userId" type NUMBER means "사용자 ID" example "1",
+                "list[].point" type OBJECT means "위치 정보",
+                "list[].point.type" type STRING means "좌표 타입" example "Point",
+                "list[].point.coordinates" type ARRAY means "좌표 배열" example "[126.977969, 37.566535]",
+                "list[].spotName" type STRING means "장소 이름" example "테스트 쓰레기통",
+                "list[].address" type OBJECT means "주소 정보",
+                "list[].address.city" type STRING means "도시" example "강남구",
+                "list[].address.site" type STRING means "상세 주소" example "서울시 강남구 강남동 1-4",
+                "list[].trashType" type ENUM(TrashType::class) means "쓰레기통 타입" example "GENERAL",
+                "list[].imageUrl" type STRING means "이미지 URL" example "https://example.com/image.jpg",
+                "list[].status" type ENUM(HistoryStatus::class) means "내역 상태" example "WAITING",
+                "list[].actionType" type ENUM(SpotActionType::class) means "액션 타입" example "REPORT",
+                "list[].createdAt" type STRING means "생성 일자" example "2024-01-01T00:00:00",
+            ),
+        )
+    }
+}

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/HistoryFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/HistoryFacade.kt
@@ -11,6 +11,8 @@ import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SuggestionService
 import com.sseudam.suggestion.SuggestionStatus
 import com.sseudam.support.Cache
+import com.sseudam.support.extension.parZipWithMDC
+import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Service
 
 @Service
@@ -24,15 +26,14 @@ class HistoryFacade(
             ttl = 10,
             typeReference = object : TypeReference<List<SpotHistory.Info>>() {},
         ) {
-            val reports =
-                reportService
-                    .findAllReportByUserId(userId)
-                    .map { it.toSpotHistoryInfo() }
-            val suggestions =
-                suggestionService
-                    .findAllSpotSuggestionByUser(userId)
-                    .map { it.toSpotHistoryInfo() }
-            return@cache (reports + suggestions).sortedByDescending { it.createdAt }
+            runBlocking {
+                parZipWithMDC(
+                    { reportService.findAllReportByUserId(userId).map { it.toSpotHistoryInfo() } },
+                    { suggestionService.findAllSpotSuggestionByUser(userId).map { it.toSpotHistoryInfo() } },
+                ) { reports, suggestions ->
+                    (reports + suggestions).sortedByDescending { it.createdAt }
+                }
+            }
         }
 
     private fun SpotReport.Info.toSpotHistoryInfo() =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이 사항

- bad108021598123383fcff045f70d54f90dee49f: History Test Code

## 📝 참고

- Cache.cache 람다는 일반 함수 컨텍스트이므로, 그 안에서 suspend 함수( parZipWithMDC)를 호출하려면 runBlocking이 필요하다.

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Improved performance of history retrieval by fetching data in parallel, reducing response times for the history screen/API.
- Documentation
  - Updated API docs for GET /api/v1/histories with detailed response fields, examples, and enum descriptions.
- Tests
  - Added comprehensive unit and integration tests for history retrieval, covering empty and mixed data scenarios, sorting by creation time, and status/action type mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->