### PR TITLE
[Feature] Report&Suggestion cancel API

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/ReportController.kt
@@ -1,9 +1,11 @@
 package com.sseudam.presentation.v1.report
 
 import com.sseudam.presentation.v1.annotation.ApiV1Controller
+import com.sseudam.presentation.v1.report.request.ReportCancelRequest
 import com.sseudam.presentation.v1.report.request.ReportValidationRequest
 import com.sseudam.presentation.v1.report.request.SpotReportCreateRequest
 import com.sseudam.presentation.v1.report.response.ReportImageUrlResponse
+import com.sseudam.presentation.v1.report.response.ReportMessageResponse
 import com.sseudam.presentation.v1.report.response.ReportValidationResponse
 import com.sseudam.presentation.v1.report.response.SpotReportAllResponse
 import com.sseudam.presentation.v1.report.response.SpotReportResponse
@@ -60,5 +62,15 @@ class ReportController(
     ): ReportValidationResponse {
         val isValid = reportFacade.validateSpotReport(request.name)
         return ReportValidationResponse.of(isValid)
+    }
+
+    @Operation(summary = "신고 취소", description = "신고를 취소합니다.")
+    @PostMapping("/reports/cancel")
+    fun reportSpotCancel(
+        user: User,
+        @RequestBody request: ReportCancelRequest,
+    ): ReportMessageResponse {
+        reportService.cancel(request.toCommand(user.id))
+        return ReportMessageResponse(message = "신고가 취소되었습니다.")
     }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/ReportCancelRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/ReportCancelRequest.kt
@@ -1,0 +1,12 @@
+package com.sseudam.presentation.v1.report.request
+
+import com.sseudam.report.command.CancelReportCommand
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "신고 취소 요청")
+data class ReportCancelRequest(
+    @Schema(description = "신고 ID", example = "1")
+    val reportId: Long,
+) {
+    fun toCommand(userId: Long) = CancelReportCommand(userId, reportId)
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/response/ReportMessageResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/response/ReportMessageResponse.kt
@@ -1,0 +1,9 @@
+package com.sseudam.presentation.v1.report.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "신고 취소 응답")
+data class ReportMessageResponse(
+    @Schema(description = "응답 메시지", example = "신고가 취소되었습니다.")
+    val message: String,
+)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
@@ -2,9 +2,11 @@ package com.sseudam.presentation.v1.suggestion
 
 import com.sseudam.presentation.v1.annotation.ApiV1Controller
 import com.sseudam.presentation.v1.suggestion.request.SpotSuggestionCreateRequest
+import com.sseudam.presentation.v1.suggestion.request.SuggestionCancelRequest
 import com.sseudam.presentation.v1.suggestion.request.SuggestionValidationRequest
 import com.sseudam.presentation.v1.suggestion.response.SpotSuggestionAllResponse
 import com.sseudam.presentation.v1.suggestion.response.SuggestionImageUrlResponse
+import com.sseudam.presentation.v1.suggestion.response.SuggestionMessageResponse
 import com.sseudam.presentation.v1.suggestion.response.SuggestionValidationResponse
 import com.sseudam.suggestion.SuggestionFacade
 import com.sseudam.suggestion.SuggestionService
@@ -48,5 +50,15 @@ class SuggestionController(
     ): SuggestionValidationResponse {
         val isValid = suggestionFacade.validateSpotSuggestion(request.name)
         return SuggestionValidationResponse.of(isValid)
+    }
+
+    @Operation(summary = "제보 취소", description = "제보를 취소합니다.")
+    @PostMapping("/suggestions/cancel")
+    fun suggestionSpotCancel(
+        user: User,
+        @RequestBody request: SuggestionCancelRequest,
+    ): SuggestionMessageResponse {
+        suggestionFacade.cancelSpotSuggestion(user.id, request.suggestionId)
+        return SuggestionMessageResponse(message = "제보가 취소되었습니다.")
     }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
@@ -58,7 +58,7 @@ class SuggestionController(
         user: User,
         @RequestBody request: SuggestionCancelRequest,
     ): SuggestionMessageResponse {
-        suggestionFacade.cancelSpotSuggestion(user.id, request.suggestionId)
+        suggestionService.cancel(request.toCommand(userId = user.id))
         return SuggestionMessageResponse(message = "제보가 취소되었습니다.")
     }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/request/SuggestionCancelRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/request/SuggestionCancelRequest.kt
@@ -1,9 +1,16 @@
 package com.sseudam.presentation.v1.suggestion.request
 
+import com.sseudam.suggestion.command.CancelSuggestionCommand
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "제보 취소 요청")
 data class SuggestionCancelRequest(
     @Schema(description = "제보 ID", example = "1")
     val suggestionId: Long,
-)
+) {
+    fun toCommand(userId: Long) =
+        CancelSuggestionCommand(
+            userId = userId,
+            suggestionId = suggestionId,
+        )
+}

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/request/SuggestionCancelRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/request/SuggestionCancelRequest.kt
@@ -1,0 +1,9 @@
+package com.sseudam.presentation.v1.suggestion.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "제보 취소 요청")
+data class SuggestionCancelRequest(
+    @Schema(description = "제보 ID", example = "1")
+    val suggestionId: Long,
+)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/response/SuggestionMessageResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/response/SuggestionMessageResponse.kt
@@ -1,0 +1,9 @@
+package com.sseudam.presentation.v1.suggestion.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "제보 메시지 응답")
+data class SuggestionMessageResponse(
+    @Schema(description = "제보 관련 응답 메시지", example = "제보가 취소되었습니다.")
+    val message: String,
+)

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/history/HistoryFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/history/HistoryFacadeTest.kt
@@ -116,6 +116,7 @@ class HistoryFacadeTest :
                             SuggestionFixture.spotSuggestionInfo.copy(status = SuggestionStatus.APPROVE),
                             SuggestionFixture.spotSuggestionInfo.copy(id = 2L, status = SuggestionStatus.REJECT),
                             SuggestionFixture.spotSuggestionInfo.copy(id = 3L, status = SuggestionStatus.WAITING),
+                            SuggestionFixture.spotSuggestionInfo.copy(id = 4L, status = SuggestionStatus.CANCEL),
                         )
 
                     every { reportService.findAllReportByUserId(userId) } returns emptyList()
@@ -123,10 +124,11 @@ class HistoryFacadeTest :
 
                     val result = historyFacade.findHistories(userId)
 
-                    result shouldHaveSize 3
+                    result shouldHaveSize 4
                     result.count { it.status == HistoryStatus.APPROVE } shouldBe 1
                     result.count { it.status == HistoryStatus.REJECT } shouldBe 1
                     result.count { it.status == HistoryStatus.WAITING } shouldBe 1
+                    result.count { it.status == HistoryStatus.CANCEL } shouldBe 1
                 }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
@@ -272,7 +272,7 @@ class ReportServiceTest :
             context("다른 사용자의 신고를 취소하려는 경우") {
                 it("예외가 발생한다") {
                     val command = ReportFixture.cancelReportCommand
-                    val reportInfo = ReportFixture.spotReportInfo.copy(userId = 2L)
+                    val reportInfo = ReportFixture.spotReportInfo.copy(userId = command.userId + 1)
 
                     every { reportReader.readBy(command.reportId) } returns reportInfo
                     every { reportValidator.verifyReport(command.userId, reportInfo) } throws ErrorException(ErrorType.UNAUTHORIZED_REPORT)
@@ -283,6 +283,7 @@ class ReportServiceTest :
 
                     verify { reportReader.readBy(command.reportId) }
                     verify { reportValidator.verifyReport(command.userId, reportInfo) }
+                    verify { reportUpdater.cancel(command.reportId) }
                 }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
@@ -259,13 +259,13 @@ class ReportServiceTest :
 
                     every { reportReader.readBy(command.reportId) } returns reportInfo
                     every { reportValidator.verifyReport(command.userId, reportInfo) } just Runs
-                    every { reportUpdater.cancel(command.reportId, ReportStatus.CANCEL) } just Runs
+                    every { reportUpdater.cancel(command.reportId) } just Runs
 
                     reportService.cancel(command)
 
                     verify { reportReader.readBy(command.reportId) }
                     verify { reportValidator.verifyReport(command.userId, reportInfo) }
-                    verify { reportUpdater.cancel(command.reportId, ReportStatus.CANCEL) }
+                    verify { reportUpdater.cancel(command.reportId) }
                 }
             }
 

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
@@ -10,6 +10,7 @@ import com.sseudam.report.SpotReport
 import com.sseudam.report.component.ReportAppender
 import com.sseudam.report.component.ReportReader
 import com.sseudam.report.component.ReportUpdater
+import com.sseudam.report.component.ReportValidator
 import com.sseudam.report.event.SpotReportUpdateEvent
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
@@ -30,9 +31,10 @@ class ReportServiceTest :
         val reportAppender: ReportAppender = mockk()
         val reportReader: ReportReader = mockk()
         val reportUpdater: ReportUpdater = mockk()
+        val reportValidator: ReportValidator = mockk()
         val applicationEventPublisher: ApplicationEventPublisher = mockk()
 
-        val reportService = ReportService(reportAppender, reportReader, reportUpdater, applicationEventPublisher)
+        val reportService = ReportService(reportAppender, reportReader, reportUpdater, reportValidator, applicationEventPublisher)
 
         describe("신고 추가") {
             context("유효한 신고 정보인 경우") {
@@ -146,12 +148,12 @@ class ReportServiceTest :
                     val reportId = 1L
                     val reportInfo = ReportFixture.spotReportInfo
 
-                    every { reportReader.readById(reportId) } returns reportInfo
+                    every { reportReader.readBy(reportId) } returns reportInfo
 
                     val result = reportService.findSpotReportById(reportId)
 
                     result shouldBe reportInfo
-                    verify { reportReader.readById(reportId) }
+                    verify { reportReader.readBy(reportId) }
                 }
             }
         }
@@ -245,6 +247,42 @@ class ReportServiceTest :
 
                     exception.errorType shouldBe ErrorType.DUPLICATE_SPOT_NAME
                     verify { reportReader.existsByName(name) }
+                }
+            }
+        }
+
+        describe("신고 취소") {
+            context("본인의 신고를 취소하는 경우") {
+                it("신고 상태를 취소로 변경한다") {
+                    val command = ReportFixture.cancelReportCommand
+                    val reportInfo = ReportFixture.spotReportInfo
+
+                    every { reportReader.readBy(command.reportId) } returns reportInfo
+                    every { reportValidator.verifyReport(command.userId, reportInfo) } just Runs
+                    every { reportUpdater.cancel(command.reportId, ReportStatus.CANCEL) } just Runs
+
+                    reportService.cancel(command)
+
+                    verify { reportReader.readBy(command.reportId) }
+                    verify { reportValidator.verifyReport(command.userId, reportInfo) }
+                    verify { reportUpdater.cancel(command.reportId, ReportStatus.CANCEL) }
+                }
+            }
+
+            context("다른 사용자의 신고를 취소하려는 경우") {
+                it("예외가 발생한다") {
+                    val command = ReportFixture.cancelReportCommand
+                    val reportInfo = ReportFixture.spotReportInfo.copy(userId = 2L)
+
+                    every { reportReader.readBy(command.reportId) } returns reportInfo
+                    every { reportValidator.verifyReport(command.userId, reportInfo) } throws ErrorException(ErrorType.UNAUTHORIZED_REPORT)
+
+                    shouldThrow<ErrorException> {
+                        reportService.cancel(command)
+                    }
+
+                    verify { reportReader.readBy(command.reportId) }
+                    verify { reportValidator.verifyReport(command.userId, reportInfo) }
                 }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
@@ -298,7 +298,7 @@ class SuggestionServiceTest :
             context("다른 사용자의 제보를 취소하려는 경우") {
                 it("예외가 발생한다") {
                     val command = SuggestionFixture.cancelSuggestionCommand
-                    val suggestionInfo = SuggestionFixture.spotSuggestionInfo.copy(userId = 2L)
+                    val suggestionInfo = SuggestionFixture.spotSuggestionInfo.copy(userId = command.userId + 1)
 
                     every { suggestionReader.readBy(command.suggestionId) } returns suggestionInfo
                     every { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) } throws ErrorException(ErrorType.UNAUTHORIZED_SUGGESTION)
@@ -309,6 +309,7 @@ class SuggestionServiceTest :
 
                     verify { suggestionReader.readBy(command.suggestionId) }
                     verify { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) }
+                    verify { suggestionUpdater.cancel(command.suggestionId) }
                 }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
@@ -172,12 +172,12 @@ class SuggestionServiceTest :
                     val suggestionInfo = SuggestionFixture.spotSuggestionInfo
 
                     every { suggestionReader.readBy(suggestionId) } returns suggestionInfo
-                    every { suggestionReader.findRejectBySuggestionId(suggestionId) } returns null
+                    every { suggestionReader.readRejectBySuggestionId(suggestionId) } returns null
 
                     val result = suggestionService.findSpotSuggestionById(suggestionId)
 
                     verify { suggestionReader.readBy(suggestionId) }
-                    verify { suggestionReader.findRejectBySuggestionId(suggestionId) }
+                    verify { suggestionReader.readRejectBySuggestionId(suggestionId) }
                 }
             }
         }
@@ -273,6 +273,44 @@ class SuggestionServiceTest :
                     suggestionService.appendReject(suggestionId, null)
 
                     verify { suggestionAppender.appendReject(suggestionId, null) }
+                }
+            }
+        }
+
+        describe("제보 취소") {
+            context("본인의 제보를 취소하는 경우") {
+                it("제보 상태를 취소로 변경한다") {
+                    val userId = 1L
+                    val suggestionId = 1L
+                    val suggestionInfo = SuggestionFixture.spotSuggestionInfo.copy(userId = userId)
+
+                    every { suggestionReader.readBy(suggestionId) } returns suggestionInfo
+                    every { suggestionValidator.verifySuggestion(userId, suggestionInfo) } just Runs
+                    every { suggestionUpdater.cancel(suggestionId, SuggestionStatus.CANCEL) } just Runs
+
+                    suggestionService.cancel(userId, suggestionId)
+
+                    verify { suggestionReader.readBy(suggestionId) }
+                    verify { suggestionValidator.verifySuggestion(userId, suggestionInfo) }
+                    verify { suggestionUpdater.cancel(suggestionId, SuggestionStatus.CANCEL) }
+                }
+            }
+
+            context("다른 사용자의 제보를 취소하려는 경우") {
+                it("예외가 발생한다") {
+                    val userId = 1L
+                    val suggestionId = 1L
+                    val suggestionInfo = SuggestionFixture.spotSuggestionInfo.copy(userId = 2L)
+
+                    every { suggestionReader.readBy(suggestionId) } returns suggestionInfo
+                    every { suggestionValidator.verifySuggestion(userId, suggestionInfo) } throws ErrorException(ErrorType.UNAUTHORIZED_SUGGESTION)
+
+                    shouldThrow<ErrorException> {
+                        suggestionService.cancel(userId, suggestionId)
+                    }
+
+                    verify { suggestionReader.readBy(suggestionId) }
+                    verify { suggestionValidator.verifySuggestion(userId, suggestionInfo) }
                 }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
@@ -285,13 +285,13 @@ class SuggestionServiceTest :
 
                     every { suggestionReader.readBy(command.suggestionId) } returns suggestionInfo
                     every { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) } just Runs
-                    every { suggestionUpdater.cancel(command.suggestionId, SuggestionStatus.CANCEL) } just Runs
+                    every { suggestionUpdater.cancel(command.suggestionId) } just Runs
 
                     suggestionService.cancel(command)
 
                     verify { suggestionReader.readBy(command.suggestionId) }
                     verify { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) }
-                    verify { suggestionUpdater.cancel(command.suggestionId, SuggestionStatus.CANCEL) }
+                    verify { suggestionUpdater.cancel(command.suggestionId) }
                 }
             }
 

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
@@ -176,6 +176,7 @@ class SuggestionServiceTest :
 
                     val result = suggestionService.findSpotSuggestionById(suggestionId)
 
+                    result shouldBe SpotSuggestion.Detail.of(suggestionInfo, null)
                     verify { suggestionReader.readBy(suggestionId) }
                     verify { suggestionReader.readRejectBySuggestionId(suggestionId) }
                 }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/suggestion/SuggestionServiceTest.kt
@@ -280,37 +280,35 @@ class SuggestionServiceTest :
         describe("제보 취소") {
             context("본인의 제보를 취소하는 경우") {
                 it("제보 상태를 취소로 변경한다") {
-                    val userId = 1L
-                    val suggestionId = 1L
-                    val suggestionInfo = SuggestionFixture.spotSuggestionInfo.copy(userId = userId)
+                    val command = SuggestionFixture.cancelSuggestionCommand
+                    val suggestionInfo = SuggestionFixture.spotSuggestionInfo
 
-                    every { suggestionReader.readBy(suggestionId) } returns suggestionInfo
-                    every { suggestionValidator.verifySuggestion(userId, suggestionInfo) } just Runs
-                    every { suggestionUpdater.cancel(suggestionId, SuggestionStatus.CANCEL) } just Runs
+                    every { suggestionReader.readBy(command.suggestionId) } returns suggestionInfo
+                    every { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) } just Runs
+                    every { suggestionUpdater.cancel(command.suggestionId, SuggestionStatus.CANCEL) } just Runs
 
-                    suggestionService.cancel(userId, suggestionId)
+                    suggestionService.cancel(command)
 
-                    verify { suggestionReader.readBy(suggestionId) }
-                    verify { suggestionValidator.verifySuggestion(userId, suggestionInfo) }
-                    verify { suggestionUpdater.cancel(suggestionId, SuggestionStatus.CANCEL) }
+                    verify { suggestionReader.readBy(command.suggestionId) }
+                    verify { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) }
+                    verify { suggestionUpdater.cancel(command.suggestionId, SuggestionStatus.CANCEL) }
                 }
             }
 
             context("다른 사용자의 제보를 취소하려는 경우") {
                 it("예외가 발생한다") {
-                    val userId = 1L
-                    val suggestionId = 1L
+                    val command = SuggestionFixture.cancelSuggestionCommand
                     val suggestionInfo = SuggestionFixture.spotSuggestionInfo.copy(userId = 2L)
 
-                    every { suggestionReader.readBy(suggestionId) } returns suggestionInfo
-                    every { suggestionValidator.verifySuggestion(userId, suggestionInfo) } throws ErrorException(ErrorType.UNAUTHORIZED_SUGGESTION)
+                    every { suggestionReader.readBy(command.suggestionId) } returns suggestionInfo
+                    every { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) } throws ErrorException(ErrorType.UNAUTHORIZED_SUGGESTION)
 
                     shouldThrow<ErrorException> {
-                        suggestionService.cancel(userId, suggestionId)
+                        suggestionService.cancel(command)
                     }
 
-                    verify { suggestionReader.readBy(suggestionId) }
-                    verify { suggestionValidator.verifySuggestion(userId, suggestionInfo) }
+                    verify { suggestionReader.readBy(command.suggestionId) }
+                    verify { suggestionValidator.verifySuggestion(command.userId, suggestionInfo) }
                 }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotFacadeTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotFacadeTest.kt
@@ -73,7 +73,12 @@ class TrashSpotFacadeTest :
 
                 every { service.findBy(1L) } returns spot
                 every { imageService.findBySpotId(1L) } returns listOf(image)
-                every { suggestionService.findSpotSuggestionByPoint(geoConverter.geoJsonPointToJtsPoint(spot.point as GeoJson.Point)) } returns suggestion
+                every {
+                    suggestionService.findSpotSuggestionByPointAndStatus(
+                        geoConverter.geoJsonPointToJtsPoint(spot.point as GeoJson.Point),
+                        SuggestionStatus.APPROVE,
+                    )
+                } returns suggestion
                 every { userService.getProfile(123L) } returns userProfile
                 every { visitedService.countBySpotId(1L) } returns 5L
 

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/report/ReportFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/report/ReportFixture.kt
@@ -6,11 +6,13 @@ import com.sseudam.common.GeoJson
 import com.sseudam.common.Region
 import com.sseudam.common.S3ImageUrl
 import com.sseudam.pet.PetPointAction
+import com.sseudam.presentation.v1.report.request.ReportCancelRequest
 import com.sseudam.presentation.v1.report.request.ReportValidationRequest
 import com.sseudam.presentation.v1.report.request.SpotReportCreateRequest
 import com.sseudam.report.ReportStatus
 import com.sseudam.report.ReportType
 import com.sseudam.report.SpotReport
+import com.sseudam.report.command.CancelReportCommand
 import com.sseudam.report.command.UpdateReportCommand
 import com.sseudam.report.event.SpotReportCreatedEvent
 import com.sseudam.report.event.SpotReportUpdateEvent
@@ -37,6 +39,17 @@ object ReportFixture {
     val reportValidationRequest =
         fixtureBuilder<ReportValidationRequest> {
             setExp(ReportValidationRequest::name, "테스트 쓰레기통")
+        }
+
+    val reportCancelRequest =
+        fixtureBuilder<ReportCancelRequest> {
+            setExp(ReportCancelRequest::reportId, 1L)
+        }
+
+    val cancelReportCommand =
+        fixtureBuilder<CancelReportCommand> {
+            setExp(CancelReportCommand::userId, 1L)
+            setExp(CancelReportCommand::reportId, 1L)
         }
 
     val spotReportInfo =

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/suggestion/SuggestionFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/suggestion/SuggestionFixture.kt
@@ -7,6 +7,7 @@ import com.sseudam.common.Region
 import com.sseudam.common.S3ImageUrl
 import com.sseudam.pet.PetPointAction
 import com.sseudam.presentation.v1.suggestion.request.SpotSuggestionCreateRequest
+import com.sseudam.presentation.v1.suggestion.request.SuggestionCancelRequest
 import com.sseudam.presentation.v1.suggestion.request.SuggestionValidationRequest
 import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SuggestionStatus
@@ -31,6 +32,11 @@ object SuggestionFixture {
     val suggestionValidationRequest =
         fixtureBuilder<SuggestionValidationRequest> {
             setExp(SuggestionValidationRequest::name, "테스트 쓰레기통")
+        }
+
+    val suggestionCancelRequest =
+        fixtureBuilder<SuggestionCancelRequest> {
+            setExp(SuggestionCancelRequest::suggestionId, 1L)
         }
 
     val spotSuggestionInfo =

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/suggestion/SuggestionFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/suggestion/SuggestionFixture.kt
@@ -11,6 +11,7 @@ import com.sseudam.presentation.v1.suggestion.request.SuggestionCancelRequest
 import com.sseudam.presentation.v1.suggestion.request.SuggestionValidationRequest
 import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SuggestionStatus
+import com.sseudam.suggestion.command.CancelSuggestionCommand
 import com.sseudam.suggestion.event.SpotSuggestionCreatedEvent
 import com.sseudam.test.helper.fixtureBuilder
 import com.sseudam.trashspot.TrashType
@@ -37,6 +38,12 @@ object SuggestionFixture {
     val suggestionCancelRequest =
         fixtureBuilder<SuggestionCancelRequest> {
             setExp(SuggestionCancelRequest::suggestionId, 1L)
+        }
+
+    val cancelSuggestionCommand =
+        fixtureBuilder<CancelSuggestionCommand> {
+            setExp(CancelSuggestionCommand::suggestionId, 1L)
+            setExp(CancelSuggestionCommand::userId, 1L)
         }
 
     val spotSuggestionInfo =

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/attendance/AttendanceControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/attendance/AttendanceControllerTest.kt
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import java.util.UUID
 
 @RestDocsTest
@@ -34,7 +33,7 @@ class AttendanceControllerTest : RestDocsTestSuite() {
     private lateinit var userArgumentResolver: UserArgumentResolver
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         attendanceFacade = mockk()
         userArgumentResolver = mockk()
         attendanceController = AttendanceController(attendanceFacade)

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/auth/AuthControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/auth/AuthControllerTest.kt
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import org.springframework.security.crypto.password.PasswordEncoder
 
 @RestDocsTest
@@ -45,7 +44,7 @@ class AuthControllerTest : RestDocsTestSuite() {
     private lateinit var userService: UserService
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         passwordEncoder = mockk()
         authenticationService = mockk()
         authenticationFacade = mockk()

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/history/HistoryControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/history/HistoryControllerTest.kt
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import java.util.UUID
 
 @RestDocsTest
@@ -39,7 +38,7 @@ class HistoryControllerTest : RestDocsTestSuite() {
     private lateinit var userArgumentResolver: UserArgumentResolver
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         historyFacade = mockk()
         userArgumentResolver = mockk()
         historyController = HistoryController(historyFacade)

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/pet/PetControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/pet/PetControllerTest.kt
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import java.util.UUID
 
 @RestDocsTest
@@ -43,7 +42,7 @@ class PetControllerTest : RestDocsTestSuite() {
     private lateinit var userArgumentResolver: UserArgumentResolver
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         userArgumentResolver = mockk()
         petService = mockk()
         userPetService = mockk()

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/report/ReportControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/report/ReportControllerTest.kt
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import java.util.UUID
 
 @RestDocsTest
@@ -47,7 +46,7 @@ class ReportControllerTest : RestDocsTestSuite() {
     private lateinit var userArgumentResolver: UserArgumentResolver
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         userArgumentResolver = mockk()
         reportService = mockk()
         reportFacade = mockk()

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/report/ReportControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/report/ReportControllerTest.kt
@@ -26,7 +26,9 @@ import com.sseudam.report.ReportType
 import com.sseudam.report.result.CreateSpotReportResult
 import com.sseudam.trashspot.TrashType
 import com.sseudam.user.User
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.restassured.http.ContentType
 import org.junit.jupiter.api.BeforeEach
@@ -220,6 +222,39 @@ class ReportControllerTest : RestDocsTestSuite() {
             ),
             responseBody(
                 "isValid" type BOOLEAN means "검증 결과" example "true",
+            ),
+        )
+    }
+
+    @DisplayName("신고 취소 - 200")
+    @Test
+    fun t5() {
+        val request = ReportFixture.reportCancelRequest
+
+        every { reportService.cancel(any()) } just Runs
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/reports/cancel")
+                .then()
+                .status(HttpStatus.OK)
+
+        response.makeDocument(
+            "신고 취소",
+            DocsTag.REPORT,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "ReportCancelRequest",
+            "ReportMessageResponse",
+            requestBody(
+                "reportId" type NUMBER means "취소할 신고 ID" example "1",
+            ),
+            responseBody(
+                "message" type STRING means "취소 완료 메시지" example "신고가 취소되었습니다.",
             ),
         )
     }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
@@ -180,7 +180,7 @@ class SuggestionControllerTest : RestDocsTestSuite() {
     fun t4() {
         val request = SuggestionFixture.suggestionCancelRequest
 
-        every { suggestionFacade.cancelSpotSuggestion(any(), any()) } just Runs
+        every { suggestionService.cancel(any()) } just Runs
 
         val response =
             given()

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
@@ -25,7 +25,9 @@ import com.sseudam.suggestion.SuggestionStatus
 import com.sseudam.suggestion.result.CreateSpotSuggestionResult
 import com.sseudam.trashspot.TrashType
 import com.sseudam.user.User
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.restassured.http.ContentType
 import org.junit.jupiter.api.BeforeEach
@@ -169,6 +171,39 @@ class SuggestionControllerTest : RestDocsTestSuite() {
             ),
             responseBody(
                 "isValid" type BOOLEAN means "검증 결과" example "true",
+            ),
+        )
+    }
+
+    @DisplayName("제보 취소 - 200")
+    @Test
+    fun t4() {
+        val request = SuggestionFixture.suggestionCancelRequest
+
+        every { suggestionFacade.cancelSpotSuggestion(any(), any()) } just Runs
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .contentType(ContentType.JSON)
+                .body(request)
+                .post("/api/v1/suggestions/cancel")
+                .then()
+                .status(HttpStatus.OK)
+
+        response.makeDocument(
+            "제보 취소",
+            DocsTag.SUGGESTION,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "SuggestionCancelRequest",
+            "SuggestionMessageResponse",
+            requestBody(
+                "suggestionId" type NUMBER means "취소할 제보 ID" example "1",
+            ),
+            responseBody(
+                "message" type STRING means "취소 완료 메시지" example "제보가 취소되었습니다.",
             ),
         )
     }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import java.util.UUID
 
 @RestDocsTest
@@ -46,7 +45,7 @@ class SuggestionControllerTest : RestDocsTestSuite() {
     private lateinit var userArgumentResolver: UserArgumentResolver
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         userArgumentResolver = mockk()
         suggestionService = mockk()
         suggestionFacade = mockk()

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/trashspot/TrashSpotControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/trashspot/TrashSpotControllerTest.kt
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 
 @RestDocsTest
 class TrashSpotControllerTest : RestDocsTestSuite() {
@@ -37,7 +36,7 @@ class TrashSpotControllerTest : RestDocsTestSuite() {
     private lateinit var trashSpotFacade: TrashSpotFacade
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         trashSpotFacade = mockk()
         trashSpotController = TrashSpotController(trashSpotFacade)
         mockMvcSpec = mockController(trashSpotController)

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/user/UserControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/user/UserControllerTest.kt
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import java.util.UUID
 
 @RestDocsTest
@@ -43,7 +42,7 @@ class UserControllerTest : RestDocsTestSuite() {
     private lateinit var userArgumentResolver: UserArgumentResolver
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         userArgumentResolver = mockk()
         userService = mockk()
         userFacade = mockk()

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/version/app/AppVersionControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/version/app/AppVersionControllerTest.kt
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 
 @RestDocsTest
 class AppVersionControllerTest : RestDocsTestSuite() {
@@ -29,7 +28,7 @@ class AppVersionControllerTest : RestDocsTestSuite() {
     private lateinit var appVersionService: AppVersionService
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         appVersionService = mockk()
         appVersionController = AppVersionController(appVersionService)
         mockMvcSpec = mockController(appVersionController)

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/visit/VisitedControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/visit/VisitedControllerTest.kt
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.restdocs.RestDocumentationContextProvider
 import java.util.UUID
 
 @RestDocsTest
@@ -38,7 +37,7 @@ class VisitedControllerTest : RestDocsTestSuite() {
     private lateinit var userArgumentResolver: UserArgumentResolver
 
     @BeforeEach
-    fun setUpTest(restDocumentation: RestDocumentationContextProvider) {
+    fun setUpTest() {
         userArgumentResolver = mockk()
         spotVisitedService = mockk()
         spotVisitedFacade = mockk()

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/HistoryFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/HistoryFacade.kt
@@ -52,6 +52,7 @@ class HistoryFacade(
                     ReportStatus.APPROVE -> HistoryStatus.APPROVE
                     ReportStatus.REJECT -> HistoryStatus.REJECT
                     ReportStatus.WAITING -> HistoryStatus.WAITING
+                    ReportStatus.CANCEL -> HistoryStatus.CANCEL
                 },
             createdAt = this.createdAt,
         )

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/HistoryFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/HistoryFacade.kt
@@ -72,6 +72,7 @@ class HistoryFacade(
                     SuggestionStatus.APPROVE -> HistoryStatus.APPROVE
                     SuggestionStatus.REJECT -> HistoryStatus.REJECT
                     SuggestionStatus.WAITING -> HistoryStatus.WAITING
+                    SuggestionStatus.CANCEL -> HistoryStatus.CANCEL
                 },
             createdAt = this.createdAt,
         )

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/dto/HistoryStatus.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/history/dto/HistoryStatus.kt
@@ -6,4 +6,5 @@ enum class HistoryStatus(
     APPROVE("승인"),
     REJECT("반려"),
     WAITING("대기"),
+    CANCEL("취소"),
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportService.kt
@@ -1,9 +1,11 @@
 package com.sseudam.report
 
+import com.sseudam.report.command.CancelReportCommand
 import com.sseudam.report.command.UpdateReportCommand
 import com.sseudam.report.component.ReportAppender
 import com.sseudam.report.component.ReportReader
 import com.sseudam.report.component.ReportUpdater
+import com.sseudam.report.component.ReportValidator
 import com.sseudam.report.event.SpotReportUpdateEvent
 import com.sseudam.report.reject.ReportReject
 import com.sseudam.support.cursor.OffsetPageRequest
@@ -19,6 +21,7 @@ class ReportService(
     private val reportAppender: ReportAppender,
     private val reportReader: ReportReader,
     private val reportUpdater: ReportUpdater,
+    private val reportValidator: ReportValidator,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     fun appendReport(
@@ -35,7 +38,7 @@ class ReportService(
         searchType: ReportType?,
     ): Page<SpotReport.Detail> = reportReader.readAllBy(offsetPageRequest, searchType)
 
-    fun findSpotReportById(reportId: Long): SpotReport.Info = reportReader.readById(reportId)
+    fun findSpotReportById(reportId: Long): SpotReport.Info = reportReader.readBy(reportId)
 
     fun findRejectReportByReportId(reportId: Long): ReportReject.Info? = reportReader.readRejectByReportId(reportId)
 
@@ -51,5 +54,11 @@ class ReportService(
         if (reportReader.existsByName(name)) {
             throw ErrorException(ErrorType.DUPLICATE_SPOT_NAME)
         }
+    }
+
+    fun cancel(command: CancelReportCommand) {
+        val report = reportReader.readBy(command.reportId)
+        reportValidator.verifyReport(command.userId, report)
+        reportUpdater.cancel(command.reportId, ReportStatus.CANCEL)
     }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportService.kt
@@ -59,6 +59,6 @@ class ReportService(
     fun cancel(command: CancelReportCommand) {
         val report = reportReader.readBy(command.reportId)
         reportValidator.verifyReport(command.userId, report)
-        reportUpdater.cancel(command.reportId, ReportStatus.CANCEL)
+        reportUpdater.cancel(command.reportId)
     }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/command/CancelReportCommand.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/command/CancelReportCommand.kt
@@ -1,0 +1,6 @@
+package com.sseudam.report.command
+
+data class CancelReportCommand(
+    val userId: Long,
+    val reportId: Long,
+)

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportReader.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportReader.kt
@@ -16,7 +16,7 @@ class ReportReader(
 ) {
     fun readAllByUserId(userId: Long): List<SpotReport.Info> = reportRepository.findAllInfoByUserId(userId)
 
-    fun readById(reportId: Long): SpotReport.Info = reportRepository.findById(reportId)
+    fun readBy(reportId: Long): SpotReport.Info = reportRepository.findById(reportId)
 
     fun readAllBy(
         offsetPageRequest: OffsetPageRequest,

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportUpdater.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportUpdater.kt
@@ -13,8 +13,5 @@ class ReportUpdater(
         reportStatus: ReportStatus,
     ) = reportRepository.update(reportId, reportStatus)
 
-    fun cancel(
-        reportId: Long,
-        reportStatus: ReportStatus,
-    ) = reportRepository.cancel(reportId, reportStatus)
+    fun cancel(reportId: Long) = reportRepository.cancel(reportId)
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportUpdater.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportUpdater.kt
@@ -12,4 +12,9 @@ class ReportUpdater(
         reportId: Long,
         reportStatus: ReportStatus,
     ) = reportRepository.update(reportId, reportStatus)
+
+    fun cancel(
+        reportId: Long,
+        reportStatus: ReportStatus,
+    ) = reportRepository.cancel(reportId, reportStatus)
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportValidator.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportValidator.kt
@@ -1,0 +1,22 @@
+package com.sseudam.report.component
+
+import com.sseudam.report.ReportStatus
+import com.sseudam.report.SpotReport
+import com.sseudam.support.error.ErrorException
+import com.sseudam.support.error.ErrorType
+import org.springframework.stereotype.Component
+
+@Component
+class ReportValidator {
+    fun verifyReport(
+        userId: Long,
+        report: SpotReport.Info,
+    ) {
+        if (report.userId != userId) {
+            throw ErrorException(ErrorType.UNAUTHORIZED_REPORT)
+        }
+        if (report.status != ReportStatus.APPROVE) {
+            throw ErrorException(ErrorType.ALREADY_APPROVED_REPORT)
+        }
+    }
+}

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportValidator.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/component/ReportValidator.kt
@@ -15,7 +15,7 @@ class ReportValidator {
         if (report.userId != userId) {
             throw ErrorException(ErrorType.UNAUTHORIZED_REPORT)
         }
-        if (report.status != ReportStatus.APPROVE) {
+        if (report.status == ReportStatus.APPROVE) {
             throw ErrorException(ErrorType.ALREADY_APPROVED_REPORT)
         }
     }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/repository/SpotReportRepository.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/repository/SpotReportRepository.kt
@@ -30,10 +30,7 @@ interface SpotReportRepository {
         reportStatus: ReportStatus,
     ): SpotReport.Info
 
-    fun cancel(
-        reportId: Long,
-        reportStatus: ReportStatus,
-    )
+    fun cancel(reportId: Long)
 
     fun existsByName(name: String): Boolean
 

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/repository/SpotReportRepository.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/repository/SpotReportRepository.kt
@@ -30,6 +30,11 @@ interface SpotReportRepository {
         reportStatus: ReportStatus,
     ): SpotReport.Info
 
+    fun cancel(
+        reportId: Long,
+        reportStatus: ReportStatus,
+    )
+
     fun existsByName(name: String): Boolean
 
     fun deleteBy(reportId: Long)

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionFacade.kt
@@ -46,4 +46,11 @@ class SuggestionFacade(
                 )
             }
     }
+
+    fun cancelSpotSuggestion(
+        userId: Long,
+        suggestionId: Long,
+    ) {
+        suggestionService.cancel(userId, suggestionId)
+    }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionFacade.kt
@@ -46,11 +46,4 @@ class SuggestionFacade(
                 )
             }
     }
-
-    fun cancelSpotSuggestion(
-        userId: Long,
-        suggestionId: Long,
-    ) {
-        suggestionService.cancel(userId, suggestionId)
-    }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -58,6 +58,11 @@ class SuggestionService(
 
     fun findSpotSuggestionByPoint(point: Point): SpotSuggestion.Info? = suggestionReader.readByPoint(point)
 
+    fun findSpotSuggestionByPointAndStatus(
+        point: Point,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info? = suggestionReader.readByPointAndStatus(point, status)
+
     fun findSuggestionsBy(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
@@ -65,7 +70,7 @@ class SuggestionService(
 
     fun findSpotSuggestionById(suggestionId: Long): SpotSuggestion.Detail {
         val suggestion = suggestionReader.readBy(suggestionId)
-        val rejectSuggestion = suggestionReader.findRejectBySuggestionId(suggestionId)
+        val rejectSuggestion = suggestionReader.readRejectBySuggestionId(suggestionId)
         return SpotSuggestion.Detail.of(suggestion, rejectSuggestion)
     }
 
@@ -90,5 +95,14 @@ class SuggestionService(
         if (suggestionReader.existsByName(name)) {
             throw ErrorException(ErrorType.DUPLICATE_SPOT_NAME)
         }
+    }
+
+    fun cancel(
+        userId: Long,
+        suggestionId: Long,
+    ) {
+        val suggestion = suggestionReader.readBy(suggestionId)
+        suggestionValidator.verifySuggestion(userId, suggestion)
+        suggestionUpdater.cancel(suggestionId, SuggestionStatus.CANCEL)
     }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -1,6 +1,7 @@
 package com.sseudam.suggestion
 
 import com.sseudam.common.S3ImageUrl
+import com.sseudam.suggestion.command.CancelSuggestionCommand
 import com.sseudam.suggestion.component.SuggestionAppender
 import com.sseudam.suggestion.component.SuggestionReader
 import com.sseudam.suggestion.component.SuggestionUpdater
@@ -97,12 +98,9 @@ class SuggestionService(
         }
     }
 
-    fun cancel(
-        userId: Long,
-        suggestionId: Long,
-    ) {
-        val suggestion = suggestionReader.readBy(suggestionId)
-        suggestionValidator.verifySuggestion(userId, suggestion)
-        suggestionUpdater.cancel(suggestionId, SuggestionStatus.CANCEL)
+    fun cancel(command: CancelSuggestionCommand) {
+        val suggestion = suggestionReader.readBy(command.suggestionId)
+        suggestionValidator.verifySuggestion(command.userId, suggestion)
+        suggestionUpdater.cancel(command.suggestionId, SuggestionStatus.CANCEL)
     }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/SuggestionService.kt
@@ -101,6 +101,6 @@ class SuggestionService(
     fun cancel(command: CancelSuggestionCommand) {
         val suggestion = suggestionReader.readBy(command.suggestionId)
         suggestionValidator.verifySuggestion(command.userId, suggestion)
-        suggestionUpdater.cancel(command.suggestionId, SuggestionStatus.CANCEL)
+        suggestionUpdater.cancel(command.suggestionId)
     }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/command/CancelSuggestionCommand.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/command/CancelSuggestionCommand.kt
@@ -1,0 +1,6 @@
+package com.sseudam.suggestion.command
+
+data class CancelSuggestionCommand(
+    val userId: Long,
+    val suggestionId: Long,
+)

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionReader.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionReader.kt
@@ -28,5 +28,10 @@ class SuggestionReader(
 
     fun readByPoint(point: Point): SpotSuggestion.Info? = spotSuggestionRepository.findByPoint(point)
 
-    fun findRejectBySuggestionId(suggestionId: Long): SuggestionReject.Info? = suggestionRejectRepository.findBySuggestionId(suggestionId)
+    fun readByPointAndStatus(
+        point: Point,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info? = spotSuggestionRepository.findByPointAndStatus(point, status)
+
+    fun readRejectBySuggestionId(suggestionId: Long): SuggestionReject.Info? = suggestionRejectRepository.findBySuggestionId(suggestionId)
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionUpdater.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionUpdater.kt
@@ -14,8 +14,5 @@ class SuggestionUpdater(
         status: SuggestionStatus,
     ): SpotSuggestion.Info = spotSuggestionRepository.update(suggestionId, status)
 
-    fun cancel(
-        suggestionId: Long,
-        status: SuggestionStatus,
-    ) = spotSuggestionRepository.cancel(suggestionId, status)
+    fun cancel(suggestionId: Long) = spotSuggestionRepository.cancel(suggestionId)
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionUpdater.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionUpdater.kt
@@ -13,4 +13,9 @@ class SuggestionUpdater(
         suggestionId: Long,
         status: SuggestionStatus,
     ): SpotSuggestion.Info = spotSuggestionRepository.update(suggestionId, status)
+
+    fun cancel(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    ) = spotSuggestionRepository.cancel(suggestionId, status)
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionValidator.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/component/SuggestionValidator.kt
@@ -1,5 +1,7 @@
 package com.sseudam.suggestion.component
 
+import com.sseudam.suggestion.SpotSuggestion
+import com.sseudam.suggestion.SuggestionStatus
 import com.sseudam.suggestion.repository.SpotSuggestionRepository
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
@@ -21,6 +23,19 @@ class SuggestionValidator(
         val suggestion = suggestionRepository.findByPoint(point)
         if (suggestion != null) {
             throw ErrorException(ErrorType.ALREADY_EXIST_SPOT_POINT)
+        }
+    }
+
+    fun verifySuggestion(
+        userId: Long,
+        suggestion: SpotSuggestion.Info,
+    ) {
+        if (suggestion.userId != userId) {
+            throw ErrorException(ErrorType.UNAUTHORIZED_SUGGESTION)
+        }
+
+        if (suggestion.status == SuggestionStatus.APPROVE) {
+            throw ErrorException(ErrorType.ALREADY_APPROVED_SUGGESTION)
         }
     }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/repository/SpotSuggestionRepository.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/repository/SpotSuggestionRepository.kt
@@ -36,10 +36,7 @@ interface SpotSuggestionRepository {
         status: SuggestionStatus,
     ): SpotSuggestion.Info
 
-    fun cancel(
-        suggestionId: Long,
-        status: SuggestionStatus,
-    )
+    fun cancel(suggestionId: Long)
 
     fun existsByName(name: String): Boolean
 

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/repository/SpotSuggestionRepository.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/suggestion/repository/SpotSuggestionRepository.kt
@@ -21,6 +21,11 @@ interface SpotSuggestionRepository {
 
     fun findByPoint(point: Point): SpotSuggestion.Info?
 
+    fun findByPointAndStatus(
+        point: Point,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info?
+
     fun findAllBy(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
@@ -30,6 +35,11 @@ interface SpotSuggestionRepository {
         suggestionId: Long,
         status: SuggestionStatus,
     ): SpotSuggestion.Info
+
+    fun cancel(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    )
 
     fun existsByName(name: String): Boolean
 

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/TrashSpotFacade.kt
@@ -5,6 +5,7 @@ import com.sseudam.common.GeoConverter
 import com.sseudam.common.GeoJson
 import com.sseudam.common.Region
 import com.sseudam.suggestion.SuggestionService
+import com.sseudam.suggestion.SuggestionStatus
 import com.sseudam.support.Cache
 import com.sseudam.trashspot.dto.TrashSpotLocation
 import com.sseudam.trashspot.image.TrashSpotImageService
@@ -39,12 +40,13 @@ class TrashSpotFacade(
         ) {
             val spot = trashSpotService.findBy(spotId)
             val image = trashSpotImageService.findBySpotId(spotId).lastOrNull()
-            val suggestioner =
-                suggestionService.findSpotSuggestionByPoint(
+            val suggestion =
+                suggestionService.findSpotSuggestionByPointAndStatus(
                     geoConverter.geoJsonPointToJtsPoint(spot.point as GeoJson.Point),
+                    SuggestionStatus.APPROVE,
                 )
-            val user = suggestioner?.let { userService.getProfile(it.userId) }
+            val suggestioner = suggestion?.let { userService.getProfile(it.userId) }
             val visitedCount = visitedService.countBySpotId(spotId)
-            return@cache TrashSpotDetail(spot, image, user, visitedCount)
+            return@cache TrashSpotDetail(spot, image, suggestioner, visitedCount)
         }
 }

--- a/sseudam-core/core-contract/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
+++ b/sseudam-core/core-contract/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
@@ -134,6 +134,18 @@ enum class ErrorType(
         "이미 존재하는 쓰레기통 장소입니다.",
         ErrorLevel.WARN,
     ),
+    UNAUTHORIZED_SUGGESTION(
+        400,
+        ErrorKind.CLIENT_ERROR,
+        "해당 제보에 대한 제보자가 아닙니다.",
+        ErrorLevel.WARN,
+    ),
+    ALREADY_APPROVED_SUGGESTION(
+        409,
+        ErrorKind.CLIENT_ERROR,
+        "이미 승인된 제보입니다.",
+        ErrorLevel.WARN,
+    ),
 
     /** SPOT */
     ALREADY_EXIST_SPOT_SITE(

--- a/sseudam-core/core-contract/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
+++ b/sseudam-core/core-contract/src/main/kotlin/com/sseudam/support/error/ErrorType.kt
@@ -104,6 +104,18 @@ enum class ErrorType(
         "잘못된 신고 상태입니다.",
         ErrorLevel.WARN,
     ),
+    UNAUTHORIZED_REPORT(
+        400,
+        ErrorKind.CLIENT_ERROR,
+        "해당 신고에 대한 신고자가 아닙니다.",
+        ErrorLevel.WARN,
+    ),
+    ALREADY_APPROVED_REPORT(
+        409,
+        ErrorKind.CLIENT_ERROR,
+        "이미 승인된 신고입니다.",
+        ErrorLevel.WARN,
+    ),
 
     /** Visited */
     SPOT_VISITED_ALREADY(

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportStatus.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportStatus.kt
@@ -6,4 +6,5 @@ enum class ReportStatus(
     APPROVE("승인"),
     REJECT("반려"),
     WAITING("대기"),
+    CANCEL("취소"),
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionStatus.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/suggestion/SuggestionStatus.kt
@@ -6,4 +6,5 @@ enum class SuggestionStatus(
     APPROVE("승인"),
     REJECT("반려"),
     WAITING("대기"),
+    CANCEL("취소"),
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCoreRepository.kt
@@ -32,14 +32,14 @@ class SpotReportCoreRepository(
     override fun findById(reportId: Long): SpotReport.Info =
         Tx.readable {
             spotReportJpaRepository
-                .findByIdOrElseThrow(reportId)
+                .findByIdAndDeletedAtIsNullOrElseThrow(reportId)
                 .toSpotReport()
         }
 
     override fun findAllInfoByUserId(userId: Long): List<SpotReport.Info> =
         Tx.readable {
             spotReportJpaRepository
-                .findAllByUserId(userId)
+                .findAllByUserIdAndDeletedAtIsNull(userId)
                 .map { it.toSpotReport() }
         }
 
@@ -66,6 +66,16 @@ class SpotReportCoreRepository(
                     .findByIdOrElseThrow(reportId)
             report.updateStatus(reportStatus).toSpotReport()
         }
+
+    override fun cancel(
+        reportId: Long,
+        reportStatus: ReportStatus,
+    ) = Tx.writeable {
+        val report =
+            spotReportJpaRepository
+                .findByIdAndDeletedAtIsNullOrElseThrow(reportId)
+        report.cancel(reportStatus)
+    }
 
     override fun existsByName(name: String): Boolean =
         Tx.readable {

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCoreRepository.kt
@@ -67,15 +67,13 @@ class SpotReportCoreRepository(
             report.updateStatus(reportStatus).toSpotReport()
         }
 
-    override fun cancel(
-        reportId: Long,
-        reportStatus: ReportStatus,
-    ) = Tx.writeable {
-        val report =
-            spotReportJpaRepository
-                .findByIdAndDeletedAtIsNullOrElseThrow(reportId)
-        report.cancel(reportStatus)
-    }
+    override fun cancel(reportId: Long) =
+        Tx.writeable {
+            val report =
+                spotReportJpaRepository
+                    .findByIdAndDeletedAtIsNullOrElseThrow(reportId)
+            report.cancel()
+        }
 
     override fun existsByName(name: String): Boolean =
         Tx.readable {

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCustomRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportCustomRepository.kt
@@ -75,8 +75,9 @@ class SpotReportCustomRepository(
                         path(SpotReportEntity::id)
                             .eq(path(ReportRejectEntity::reportId)),
                     ),
-                ).where(
+                ).whereAnd(
                     path(SpotReportEntity::userId).eq(userId),
+                    path(SpotReportEntity::deletedAt).isNull(),
                 ).orderBy(
                     path(SpotReportEntity::createdAt).desc(),
                 )

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
@@ -80,4 +80,9 @@ class SpotReportEntity(
         this.status = status
         return this
     }
+
+    fun cancel(status: ReportStatus) {
+        this.status = status
+        softDelete()
+    }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
@@ -81,8 +81,8 @@ class SpotReportEntity(
         return this
     }
 
-    fun cancel(status: ReportStatus) {
-        this.status = status
+    fun cancel() {
+        this.status = ReportStatus.CANCEL
         softDelete()
     }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportJpaRepository.kt
@@ -8,5 +8,7 @@ interface SpotReportJpaRepository :
     KotlinJdslJpqlExecutor {
     fun findAllByUserId(userId: Long): List<SpotReportEntity>
 
+    fun findAllByUserIdAndDeletedAtIsNull(userId: Long): List<SpotReportEntity>
+
     fun existsBySpotName(name: String): Boolean
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
@@ -83,13 +83,11 @@ class SpotSuggestionCoreRepository(
             return@writeable suggestion.updateStatus(status).toSpotSuggestion()
         }
 
-    override fun cancel(
-        suggestionId: Long,
-        status: SuggestionStatus,
-    ) = Tx.writeable {
-        val suggestion = spotSuggestionJpaRepository.findByIdAndDeletedAtIsNullOrElseThrow(suggestionId)
-        suggestion.cancel(status)
-    }
+    override fun cancel(suggestionId: Long) =
+        Tx.writeable {
+            val suggestion = spotSuggestionJpaRepository.findByIdAndDeletedAtIsNullOrElseThrow(suggestionId)
+            suggestion.cancel()
+        }
 
     override fun existsByName(name: String): Boolean =
         Tx.readable {

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionCoreRepository.kt
@@ -31,14 +31,14 @@ class SpotSuggestionCoreRepository(
     override fun findBy(suggestionId: Long): SpotSuggestion.Info =
         Tx.readable {
             spotSuggestionJpaRepository
-                .findByIdOrElseThrow(suggestionId)
+                .findByIdAndDeletedAtIsNullOrElseThrow(suggestionId)
                 .toSpotSuggestion()
         }
 
     override fun findAllByUserId(userId: Long): List<SpotSuggestion.Info> =
         Tx.readable {
             spotSuggestionJpaRepository
-                .findAllByUserId(userId)
+                .findAllByUserIdAndDeletedAtIsNull(userId)
                 .map { it.toSpotSuggestion() }
         }
 
@@ -53,6 +53,16 @@ class SpotSuggestionCoreRepository(
         Tx.readable {
             spotSuggestionJpaRepository
                 .findByPointAndDeletedAtIsNull(point)
+                ?.toSpotSuggestion()
+        }
+
+    override fun findByPointAndStatus(
+        point: Point,
+        status: SuggestionStatus,
+    ): SpotSuggestion.Info? =
+        Tx.readable {
+            spotSuggestionJpaRepository
+                .findByPointAndStatusAndDeletedAtIsNull(point, status)
                 ?.toSpotSuggestion()
         }
 
@@ -73,9 +83,17 @@ class SpotSuggestionCoreRepository(
             return@writeable suggestion.updateStatus(status).toSpotSuggestion()
         }
 
+    override fun cancel(
+        suggestionId: Long,
+        status: SuggestionStatus,
+    ) = Tx.writeable {
+        val suggestion = spotSuggestionJpaRepository.findByIdAndDeletedAtIsNullOrElseThrow(suggestionId)
+        suggestion.cancel(status)
+    }
+
     override fun existsByName(name: String): Boolean =
         Tx.readable {
-            spotSuggestionJpaRepository.existsBySpotName(name)
+            spotSuggestionJpaRepository.existsBySpotNameAndDeletedAtIsNull(name)
         }
 
     override fun deleteBy(suggestionId: Long) =

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
@@ -71,4 +71,9 @@ class SpotSuggestionEntity(
         this.status = status
         return this
     }
+
+    fun cancel(status: SuggestionStatus) {
+        this.status = status
+        softDelete()
+    }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionEntity.kt
@@ -72,8 +72,8 @@ class SpotSuggestionEntity(
         return this
     }
 
-    fun cancel(status: SuggestionStatus) {
-        this.status = status
+    fun cancel() {
+        this.status = SuggestionStatus.CANCEL
         softDelete()
     }
 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionJpaRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/suggestion/SpotSuggestionJpaRepository.kt
@@ -1,17 +1,25 @@
 package com.sseudam.storage.db.core.suggestion
 
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import com.sseudam.suggestion.SuggestionStatus
 import org.locationtech.jts.geom.Point
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface SpotSuggestionJpaRepository :
     JpaRepository<SpotSuggestionEntity, Long>,
     KotlinJdslJpqlExecutor {
-    fun findAllByUserId(userId: Long): List<SpotSuggestionEntity>
+    fun findAllByUserIdAndDeletedAtIsNull(userId: Long): List<SpotSuggestionEntity>
 
     fun findByAddressSiteAndDeletedAtIsNull(site: String): SpotSuggestionEntity?
 
     fun findByPointAndDeletedAtIsNull(point: Point): SpotSuggestionEntity?
 
-    fun existsBySpotName(name: String): Boolean
+    fun findByPointAndStatusAndDeletedAtIsNull(
+        point: Point,
+        status: SuggestionStatus,
+    ): SpotSuggestionEntity?
+
+    fun findByIdAndDeletedAtIsNull(suggestionId: Long): SpotSuggestionEntity?
+
+    fun existsBySpotNameAndDeletedAtIsNull(name: String): Boolean
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #255 

## 📌 작업 내용 및 특이 사항

- f38c98cde7cab77b6a426b35969c7ba752278c57: 제보 취소하기 기능
- 926a3d57ab8720f5c8dfc70a4833ce0103e030d4: 신고 취소하기 기능

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added endpoints to cancel reports and suggestions with user-facing confirmation messages.
  - Introduced a "Canceled" status shown in history and listings.

- **Bug Fixes**
  - Lists and history now exclude deleted items to avoid stale entries.
  - Spot detail now references only approved suggestions for accurate display.
  - Improved validation and clearer error responses for cancellation scenarios.

- **Tests**
  - Added controller and service tests covering cancellation and authorization paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->