### PR TITLE
[Feature] Suggestion detail API

### DIFF
--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionController.kt
@@ -5,6 +5,7 @@ import com.sseudam.presentation.v1.suggestion.request.SpotSuggestionCreateReques
 import com.sseudam.presentation.v1.suggestion.request.SuggestionCancelRequest
 import com.sseudam.presentation.v1.suggestion.request.SuggestionValidationRequest
 import com.sseudam.presentation.v1.suggestion.response.SpotSuggestionAllResponse
+import com.sseudam.presentation.v1.suggestion.response.SpotSuggestionDetailResponse
 import com.sseudam.presentation.v1.suggestion.response.SuggestionImageUrlResponse
 import com.sseudam.presentation.v1.suggestion.response.SuggestionMessageResponse
 import com.sseudam.presentation.v1.suggestion.response.SuggestionValidationResponse
@@ -14,6 +15,7 @@ import com.sseudam.user.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
@@ -32,6 +34,16 @@ class SuggestionController(
         val suggestion =
             suggestionFacade.createSpotSuggestion(request.toCommand(user.id))
         return SuggestionImageUrlResponse.of(suggestion.suggestionInfo, suggestion.uploadUrl)
+    }
+
+    @Operation(summary = "제보 상세 조회", description = "제보한 장소에 대한 상세 정보를 조회합니다.")
+    @GetMapping("/suggestions/{suggestionId}")
+    fun suggestionSpotDetail(
+        user: User,
+        @PathVariable suggestionId: Long,
+    ): SpotSuggestionDetailResponse {
+        val suggestion = suggestionService.findSpotSuggestionById(suggestionId)
+        return SpotSuggestionDetailResponse.from(suggestion)
     }
 
     // TODO: cursor pagination (infinity scroll)

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/response/SpotSuggestionAllResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/response/SpotSuggestionAllResponse.kt
@@ -9,6 +9,6 @@ data class SpotSuggestionAllResponse(
 ) {
     companion object {
         fun of(spots: List<SpotSuggestion.Info>): SpotSuggestionAllResponse =
-            SpotSuggestionAllResponse(spots.map { SpotSuggestionResponse.of(it) })
+            SpotSuggestionAllResponse(spots.map { SpotSuggestionResponse.from(it) })
     }
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/response/SpotSuggestionDetailResponse.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/suggestion/response/SpotSuggestionDetailResponse.kt
@@ -9,8 +9,8 @@ import com.sseudam.trashspot.TrashType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
-@Schema(description = "제보 내역 응답")
-data class SpotSuggestionResponse(
+@Schema(description = "제보 상세 내역 응답")
+data class SpotSuggestionDetailResponse(
     @Schema(description = "제보 ID")
     val id: Long,
     @Schema(description = "제보 위치")
@@ -25,20 +25,23 @@ data class SpotSuggestionResponse(
     val imageUrl: String,
     @Schema(description = "제보 상태")
     val status: SuggestionStatus,
+    @Schema(description = "반려 사유")
+    val rejectReason: String?,
     @Schema(description = "제보 시간")
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun from(suggestion: SpotSuggestion.Info) =
-            SpotSuggestionResponse(
-                id = suggestion.id,
-                point = suggestion.point,
-                region = suggestion.region,
-                address = suggestion.address,
-                trashType = suggestion.trashType,
-                imageUrl = suggestion.imageUrl,
-                status = suggestion.status,
-                createdAt = suggestion.createdAt,
+        fun from(detail: SpotSuggestion.Detail) =
+            SpotSuggestionDetailResponse(
+                id = detail.id,
+                point = detail.point,
+                region = detail.region,
+                address = detail.address,
+                trashType = detail.trashType,
+                imageUrl = detail.imageUrl,
+                status = detail.status,
+                rejectReason = detail.rejectReason,
+                createdAt = detail.createdAt,
             )
     }
 }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/suggestion/SuggestionFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/suggestion/SuggestionFixture.kt
@@ -60,6 +60,21 @@ object SuggestionFixture {
             setExp(SpotSuggestion.Info::createdAt, LocalDateTime.now())
         }
 
+    val spotSuggestionDetail =
+        fixtureBuilder<SpotSuggestion.Detail> {
+            setExp(SpotSuggestion.Detail::id, 1L)
+            setExp(SpotSuggestion.Detail::userId, 1L)
+            setExp(SpotSuggestion.Detail::spotName, "테스트 쓰레기통")
+            setExp(SpotSuggestion.Detail::point, randomPoint())
+            setExp(SpotSuggestion.Detail::region, Region.SEOUL)
+            setExp(SpotSuggestion.Detail::address, Address("강남구", "서울시 강남구 강남동 1-4"))
+            setExp(SpotSuggestion.Detail::trashType, TrashType.GENERAL)
+            setExp(SpotSuggestion.Detail::imageUrl, "https://example.com/image.jpg")
+            setExp(SpotSuggestion.Detail::status, SuggestionStatus.WAITING)
+            setExp(SpotSuggestion.Detail::rejectReason, null)
+            setExp(SpotSuggestion.Detail::createdAt, LocalDateTime.now())
+        }
+
     val s3ImageUrl =
         fixtureBuilder<S3ImageUrl> {
             setExp(S3ImageUrl::presignedUrl, "https://example.com/presigned-url")

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/suggestion/SuggestionControllerTest.kt
@@ -206,4 +206,43 @@ class SuggestionControllerTest : RestDocsTestSuite() {
             ),
         )
     }
+
+    @DisplayName("제보 상세 조회 - 200")
+    @Test
+    fun t5() {
+        val suggestionDetail = SuggestionFixture.spotSuggestionDetail
+
+        every { suggestionService.findSpotSuggestionById(any()) } returns suggestionDetail
+
+        val response =
+            given()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                .get("/api/v1/suggestions/{suggestionId}", 1L)
+                .then()
+                .status(HttpStatus.OK)
+
+        response.makeDocument(
+            "제보 상세 조회",
+            DocsTag.SUGGESTION,
+            headers(
+                "Authorization" headerType Authorization,
+            ),
+            "SpotSuggestionDetailResponse",
+            responseBody(
+                "id" type NUMBER means "제보 ID" example "1",
+                "point" type OBJECT means "제보 위치",
+                "point.type" type STRING means "좌표 타입" example "Point",
+                "point.coordinates" type ARRAY means "좌표 배열" example "[126.977969, 37.566535]",
+                "region" type ENUM(Region::class) means "제보 지역" example "SEOUL",
+                "address" type OBJECT means "제보 주소",
+                "address.city" type STRING means "도시" example "강남구",
+                "address.site" type STRING means "상세 주소" example "서울시 강남구 강남동 1-4",
+                "trashType" type ENUM(TrashType::class) means "제보 쓰레기통 타입" example "GENERAL",
+                "imageUrl" type STRING means "제보된 쓰레기통 이미지" example "https://example.com/image.jpg",
+                "status" type ENUM(SuggestionStatus::class) means "제보 상태" example "WAITING",
+                "rejectReason" type STRING means "반려 사유" example "정보가 잘못되었어요" isOptional true,
+                "createdAt" type STRING means "제보 시간" example "2024-01-01T00:00:00",
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #258 

## 📌 작업 내용 및 특이 사항

- 85aa6fd653479eb06e2e793b2e60499bd3d196a4: 제보 상세 내역 조회

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added API endpoint to retrieve detailed information for a specific suggestion by ID, including location, region, address, trash type, image URL, status, optional reject reason, and created time.

- Documentation
  - Expanded API documentation to include the new suggestion detail response with field descriptions and schema examples.

- Tests
  - Added automated test covering successful retrieval (200 OK) of suggestion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->