### PR TITLE
[Refacor] Add ReportType (ETC, EMPTY_SPOT)

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/request/report/AdminUpdateReportRequest.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/request/report/AdminUpdateReportRequest.kt
@@ -11,13 +11,13 @@ data class AdminUpdateReportRequest(
     @Schema(description = "신고 상태", example = "APPROVE")
     val status: ReportStatus,
     @Schema(description = "반려 사유", example = "장소가 다름.")
-    val reason: String? = null,
+    val rejectReason: String? = null,
 ) {
     fun toCommand(reportId: Long) =
         UpdateReportCommand(
             reportId = reportId,
             spotId = spotId,
             status = status,
-            reason = reason,
+            rejectReason = rejectReason,
         )
 }

--- a/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/SpotReportCreateRequest.kt
+++ b/sseudam-core/core-api/src/main/kotlin/com/sseudam/presentation/v1/report/request/SpotReportCreateRequest.kt
@@ -24,6 +24,8 @@ data class SpotReportCreateRequest(
     val site: String,
     @Schema(description = "쓰레기통 유형", example = "GENERAL")
     val trashType: TrashType,
+    @Schema(description = "기타 신고 사유", example = "잘못된 위치에 있어요")
+    val reason: String? = null,
 ) {
     fun toCommand(
         userId: Long,
@@ -40,5 +42,6 @@ data class SpotReportCreateRequest(
             city = city,
             site = site,
             trashType = trashType,
+            reason = reason,
         )
 }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
@@ -51,6 +51,38 @@ class ReportServiceTest :
                     verify { reportAppender.append(imageUrl, create) }
                 }
             }
+
+            context("기타 사유와 함께 신고하는 경우") {
+                it("reason 필드를 포함하여 신고를 생성한다") {
+                    val imageUrl = "https://example.com/image.jpg"
+                    val create = ReportFixture.spotReportCreate.copy(reason = "기타 사유입니다")
+                    val reportInfo = ReportFixture.spotReportInfo.copy(reason = "기타 사유입니다")
+
+                    every { reportAppender.append(imageUrl, create) } returns reportInfo
+
+                    val result = reportService.appendReport(imageUrl, create)
+
+                    result shouldBe reportInfo
+                    result.reason shouldBe "기타 사유입니다"
+                    verify { reportAppender.append(imageUrl, create) }
+                }
+            }
+
+            context("EMPTY_SPOT 타입으로 신고하는 경우") {
+                it("쓰레기통이 없는 장소로 신고를 생성한다") {
+                    val imageUrl = "https://example.com/image.jpg"
+                    val create = ReportFixture.spotReportCreate.copy(reportType = ReportType.EMPTY_SPOT)
+                    val reportInfo = ReportFixture.emptySpotReportInfo
+
+                    every { reportAppender.append(imageUrl, create) } returns reportInfo
+
+                    val result = reportService.appendReport(imageUrl, create)
+
+                    result shouldBe reportInfo
+                    result.reportType shouldBe ReportType.EMPTY_SPOT
+                    verify { reportAppender.append(imageUrl, create) }
+                }
+            }
         }
 
         describe("사용자별 신고 내역 조회") {

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/report/ReportServiceTest.kt
@@ -206,7 +206,7 @@ class ReportServiceTest :
 
             context("거절 사유와 함께 상태 변경하는 경우") {
                 it("상태를 업데이트하고 사유와 함께 이벤트를 발행한다") {
-                    val updateCommand = ReportFixture.updateReportCommand.copy(status = ReportStatus.REJECT, reason = "부적절한 위치")
+                    val updateCommand = ReportFixture.updateReportCommand.copy(status = ReportStatus.REJECT, rejectReason = "부적절한 위치")
                     val reportInfo = ReportFixture.spotReportInfo
 
                     every { reportUpdater.update(updateCommand.reportId, updateCommand.status) } returns reportInfo
@@ -216,7 +216,7 @@ class ReportServiceTest :
 
                     result shouldBe reportInfo
                     verify { reportUpdater.update(updateCommand.reportId, updateCommand.status) }
-                    verify { applicationEventPublisher.publishEvent(SpotReportUpdateEvent(reportInfo, updateCommand.reason)) }
+                    verify { applicationEventPublisher.publishEvent(SpotReportUpdateEvent(reportInfo, updateCommand.rejectReason)) }
                 }
             }
         }

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotServiceTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotServiceTest.kt
@@ -5,6 +5,7 @@ import com.sseudam.common.Address
 import com.sseudam.common.GeoConverter
 import com.sseudam.common.GeoJson
 import com.sseudam.common.Region
+import com.sseudam.fixture.report.ReportFixture
 import com.sseudam.trashspot.TrashSpot
 import com.sseudam.trashspot.TrashSpotService
 import com.sseudam.trashspot.TrashType
@@ -17,6 +18,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 
 @DevelopTest
 class TrashSpotServiceTest :
@@ -47,6 +49,20 @@ class TrashSpotServiceTest :
                 val actual = service.findAll(region = Region.SEOUL, trashType = null, location = TrashSpotLocation.notSet())
 
                 actual.shouldContainExactly(expected)
+            }
+        }
+
+        describe("updateSpotByReport") {
+            context("EMPTY_SPOT 타입의 신고인 경우") {
+                it("쓰레기통을 삭제 처리한다") {
+                    val report = ReportFixture.emptySpotReportInfo
+
+                    every { updater.updateAsEmptySpot(report.spotId) } returns Unit
+
+                    service.updateByReport(report)
+
+                    verify { updater.updateAsEmptySpot(report.spotId) }
+                }
             }
         }
     })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotUpdaterTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/application/trashspot/TrashSpotUpdaterTest.kt
@@ -1,0 +1,30 @@
+package com.sseudam.application.trashspot
+
+import com.sseudam.DevelopTest
+import com.sseudam.trashspot.component.TrashSpotUpdater
+import com.sseudam.trashspot.repository.TrashSpotRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+@DevelopTest
+class TrashSpotUpdaterTest :
+    DescribeSpec({
+        val trashSpotRepository: TrashSpotRepository = mockk(relaxed = true)
+        val updater = TrashSpotUpdater(trashSpotRepository)
+
+        describe("updateAsEmptySpot") {
+            context("쓰레기통이 없는 장소로 신고된 경우") {
+                it("해당 쓰레기통을 삭제 처리한다") {
+                    val spotId = 1L
+
+                    every { trashSpotRepository.updateAsEmptySpot(spotId) } returns Unit
+
+                    updater.updateAsEmptySpot(spotId)
+
+                    verify { trashSpotRepository.updateAsEmptySpot(spotId) }
+                }
+            }
+        }
+    })

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/report/ReportFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/report/ReportFixture.kt
@@ -34,6 +34,7 @@ object ReportFixture {
             setExp(SpotReportCreateRequest::city, "강남구")
             setExp(SpotReportCreateRequest::site, "서울시 강남구 강남동 1-4")
             setExp(SpotReportCreateRequest::trashType, TrashType.GENERAL)
+            setExp(SpotReportCreateRequest::reason, "잘못된 위치에 있어요")
         }
 
     val reportValidationRequest =
@@ -103,6 +104,7 @@ object ReportFixture {
             setExp(SpotReport.Create::city, "강남구")
             setExp(SpotReport.Create::site, "서울시 강남구 강남동 1-4")
             setExp(SpotReport.Create::trashType, TrashType.GENERAL)
+            setExp(SpotReport.Create::reason, "잘못된 위치에 있어요")
         }
 
     val trashSpotImageInfo =
@@ -125,7 +127,7 @@ object ReportFixture {
             setExp(UpdateReportCommand::reportId, 1L)
             setExp(UpdateReportCommand::spotId, 1L)
             setExp(UpdateReportCommand::status, ReportStatus.APPROVE)
-            setExp(UpdateReportCommand::reason, null)
+            setExp(UpdateReportCommand::rejectReason, null)
         }
 
     val spotReportUpdateEvent =

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/report/ReportFixture.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/fixture/report/ReportFixture.kt
@@ -66,6 +66,41 @@ object ReportFixture {
             setExp(SpotReport.Info::trashType, TrashType.GENERAL)
             setExp(SpotReport.Info::imageUrl, "https://example.com/image.jpg")
             setExp(SpotReport.Info::status, ReportStatus.WAITING)
+            setExp(SpotReport.Info::reason, "잘못된 위치에 있어요")
+            setExp(SpotReport.Info::createdAt, LocalDateTime.now())
+        }
+
+    val emptySpotReportInfo =
+        fixtureBuilder<SpotReport.Info> {
+            setExp(SpotReport.Info::id, 2L)
+            setExp(SpotReport.Info::spotId, 1L)
+            setExp(SpotReport.Info::userId, 1L)
+            setExp(SpotReport.Info::reportType, ReportType.EMPTY_SPOT)
+            setExp(SpotReport.Info::point, randomPoint())
+            setExp(SpotReport.Info::spotName, "테스트 쓰레기통")
+            setExp(SpotReport.Info::region, Region.SEOUL)
+            setExp(SpotReport.Info::address, Address("강남구", "서울시 강남구 강남동 1-4"))
+            setExp(SpotReport.Info::trashType, TrashType.GENERAL)
+            setExp(SpotReport.Info::imageUrl, "https://example.com/image.jpg")
+            setExp(SpotReport.Info::status, ReportStatus.WAITING)
+            setExp(SpotReport.Info::reason, null)
+            setExp(SpotReport.Info::createdAt, LocalDateTime.now())
+        }
+
+    val etcReportInfo =
+        fixtureBuilder<SpotReport.Info> {
+            setExp(SpotReport.Info::id, 3L)
+            setExp(SpotReport.Info::spotId, 1L)
+            setExp(SpotReport.Info::userId, 1L)
+            setExp(SpotReport.Info::reportType, ReportType.ETC)
+            setExp(SpotReport.Info::point, randomPoint())
+            setExp(SpotReport.Info::spotName, "테스트 쓰레기통")
+            setExp(SpotReport.Info::region, Region.SEOUL)
+            setExp(SpotReport.Info::address, Address("강남구", "서울시 강남구 강남동 1-4"))
+            setExp(SpotReport.Info::trashType, TrashType.GENERAL)
+            setExp(SpotReport.Info::imageUrl, "https://example.com/image.jpg")
+            setExp(SpotReport.Info::status, ReportStatus.WAITING)
+            setExp(SpotReport.Info::reason, "기타 사유입니다")
             setExp(SpotReport.Info::createdAt, LocalDateTime.now())
         }
 
@@ -83,6 +118,7 @@ object ReportFixture {
             setExp(SpotReport.Detail::imageUrl, "https://example.com/image.jpg")
             setExp(SpotReport.Detail::status, ReportStatus.WAITING)
             setExp(SpotReport.Detail::rejectReason, null)
+            setExp(SpotReport.Detail::reason, "잘못된 위치에 있어요")
             setExp(SpotReport.Detail::createdAt, LocalDateTime.now())
         }
 

--- a/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/report/ReportControllerTest.kt
+++ b/sseudam-core/core-api/src/test/kotlin/com/sseudam/presentation/v1/report/ReportControllerTest.kt
@@ -95,6 +95,7 @@ class ReportControllerTest : RestDocsTestSuite() {
                 "city" type STRING means "구/군/시" example "강남구",
                 "site" type STRING means "주소" example "서울시 강남구 강남동 1-4",
                 "trashType" type ENUM(TrashType::class) means "쓰레기통 유형" example "GENERAL",
+                "reason" type STRING means "기타 신고 사유" example "잘못된 위치에 있어요" isOptional true,
             ),
             responseBody(
                 "reportId" type NUMBER means "신고 ID" example "1",

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportFacade.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportFacade.kt
@@ -40,20 +40,20 @@ class ReportFacade(
 
     @Transactional
     fun createSpotReport(create: SpotReport.Create): CreateSpotReportResult {
-        val presignedUrl: String?
         val images = trashSpotImageService.findBySpotId(create.spotId)
         var imageUrl =
             images
                 .filter { it.updatedAt != null }
                 .maxByOrNull { it.updatedAt!! }
                 ?.imageUrl ?: DEFAULT_REPORT_IMAGE_URL
-        if (create.reportType == ReportType.PHOTO) {
-            val s3ImageUrl: S3ImageUrl = imageS3Caller.createUploadUrl(create.userId, REPORT_IMAGE_PATH + "/${create.spotId}")
-            presignedUrl = s3ImageUrl.presignedUrl
-            imageUrl = s3ImageUrl.imageUrl
-        } else {
-            presignedUrl = null
-        }
+        val presignedUrl =
+            if (create.reportType == ReportType.PHOTO) {
+                val s3ImageUrl: S3ImageUrl = imageS3Caller.createUploadUrl(create.userId, REPORT_IMAGE_PATH + "/${create.spotId}")
+                imageUrl = s3ImageUrl.imageUrl
+                s3ImageUrl.presignedUrl
+            } else {
+                null
+            }
 
         val spotReport =
             reportService.appendReport(imageUrl, create).apply {

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/ReportService.kt
@@ -46,7 +46,7 @@ class ReportService(
     fun updateSpotReport(updateReportCommand: UpdateReportCommand): SpotReport.Info =
         reportUpdater.update(updateReportCommand.reportId, updateReportCommand.status).also { report ->
             applicationEventPublisher.publishEvent(
-                SpotReportUpdateEvent(report, updateReportCommand.reason),
+                SpotReportUpdateEvent(report, updateReportCommand.rejectReason),
             )
         }
 

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/command/UpdateReportCommand.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/command/UpdateReportCommand.kt
@@ -6,5 +6,5 @@ data class UpdateReportCommand(
     val reportId: Long,
     val spotId: Long,
     val status: ReportStatus,
-    val reason: String?,
+    val rejectReason: String?,
 )

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/dto/SendMessageReportDto.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/report/dto/SendMessageReportDto.kt
@@ -41,6 +41,8 @@ data class SendMessageReportDto(
                     ReportType.NAME -> report.spotName
                     ReportType.KIND -> report.trashType.displayName
                     ReportType.PHOTO -> report.imageUrl
+                    ReportType.EMPTY_SPOT -> "잘못된 쓰레기통 장소"
+                    ReportType.ETC -> "기타 사유"
                 }
             } 로 수정 요청",
             createdAt = report.createdAt,

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/TrashSpotService.kt
@@ -6,6 +6,7 @@ import com.sseudam.common.Region
 import com.sseudam.report.ReportType
 import com.sseudam.report.SpotReport
 import com.sseudam.suggestion.SpotSuggestion
+import com.sseudam.support.Cache
 import com.sseudam.support.error.ErrorException
 import com.sseudam.support.error.ErrorType
 import com.sseudam.trashspot.component.FindTrashSpotPolicyCondition
@@ -79,6 +80,13 @@ class TrashSpotService(
             ReportType.POINT -> {
                 val jtsPoint = geoConverter.geoJsonPointToJtsPoint(report.point as GeoJson.Point)
                 trashSpotUpdater.updateLocation(report.spotId, report.region, jtsPoint)
+            }
+            ReportType.EMPTY_SPOT -> {
+                trashSpotUpdater
+                    .updateAsEmptySpot(report.spotId)
+                    .also {
+                        Cache.delete("spot:detail:${report.spotId}")
+                    }
             }
             else -> {}
         }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/component/TrashSpotUpdater.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/component/TrashSpotUpdater.kt
@@ -31,4 +31,8 @@ class TrashSpotUpdater(
     ) {
         trashSpotRepository.updateLocation(spotId, region, point)
     }
+
+    fun updateAsEmptySpot(spotId: Long) {
+        trashSpotRepository.updateAsEmptySpot(spotId)
+    }
 }

--- a/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/repository/TrashSpotRepository.kt
+++ b/sseudam-core/core-application/src/main/kotlin/com/sseudam/trashspot/repository/TrashSpotRepository.kt
@@ -51,5 +51,7 @@ interface TrashSpotRepository {
         point: Point,
     )
 
+    fun updateAsEmptySpot(spotId: Long)
+
     fun existsByName(name: String): Boolean
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportType.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/ReportType.kt
@@ -7,4 +7,6 @@ enum class ReportType(
     KIND("쓰레기통 종류"),
     PHOTO("쓰레기통 사진"),
     NAME("쓰레기통 이름"),
+    EMPTY_SPOT("이 위치에 쓰레기통이 없어요"),
+    ETC("기타"),
 }

--- a/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReport.kt
+++ b/sseudam-core/core-domain/src/main/kotlin/com/sseudam/report/SpotReport.kt
@@ -12,13 +12,14 @@ class SpotReport {
      * @property spotId 쓰레기통 위치 id
      * @property userId 신고자 id
      * @property reportType 신고 타입
-     * @property latitude 제보 위치 위도
-     * @property longitude 제보 위치 경도
+     * @property latitude 신고 위치 위도
+     * @property longitude 신고 위치 경도
      * @property spotName 쓰레기통 이름
-     * @property region 제보 지역
-     * @property city 제보 지역
-     * @property site 제보 주소
+     * @property region 신고 지역
+     * @property city 신고 지역
+     * @property site 신고 주소
      * @property trashType 쓰레기통 타입
+     * @property reason 신고 사유
      */
     data class Create(
         val spotId: Long,
@@ -31,6 +32,7 @@ class SpotReport {
         val city: String,
         val site: String,
         val trashType: TrashType,
+        val reason: String?,
     )
 
     /** SpotReport Info
@@ -40,7 +42,7 @@ class SpotReport {
      * @property reportType 신고 타입
      * @property point 신고 위치
      * @property spotName 쓰레기통 이름
-     * @property region 제보 지역
+     * @property region 신고 지역
      * @property address 신고 주소
      * @property trashType 쓰레기통 타입
      * @property imageUrl 신고된 S3 imageUrl
@@ -59,6 +61,7 @@ class SpotReport {
         val trashType: TrashType,
         val imageUrl: String,
         val status: ReportStatus = ReportStatus.WAITING,
+        val reason: String?,
         val createdAt: LocalDateTime,
     )
 
@@ -69,7 +72,7 @@ class SpotReport {
      * @property reportType 신고 타입
      * @property point 신고 위치
      * @property spotName 쓰레기통 이름
-     * @property region 제보 지역
+     * @property region 신고 지역
      * @property address 신고 주소
      * @property trashType 쓰레기통 타입
      * @property imageUrl 신고된 S3 imageUrl
@@ -90,6 +93,7 @@ class SpotReport {
         val imageUrl: String,
         val status: ReportStatus = ReportStatus.WAITING,
         val rejectReason: String?,
+        val reason: String?,
         val createdAt: LocalDateTime,
     ) {
         companion object {
@@ -111,6 +115,7 @@ class SpotReport {
                         imageUrl = imageUrl,
                         status = status,
                         rejectReason = reject?.reason,
+                        reason = reason,
                         createdAt = createdAt,
                     )
                 }

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/report/SpotReportEntity.kt
@@ -38,6 +38,7 @@ class SpotReportEntity(
     @Enumerated(value = EnumType.STRING)
     @Column(length = 15)
     var status: ReportStatus,
+    val reason: String?,
 ) : BaseEntity() {
     constructor(
         imageUrl: String,
@@ -58,6 +59,7 @@ class SpotReportEntity(
         trashType = createSpotReport.trashType,
         imageUrl = imageUrl,
         status = ReportStatus.WAITING,
+        reason = createSpotReport.reason,
     )
 
     fun toSpotReport(): SpotReport.Info =
@@ -74,6 +76,7 @@ class SpotReportEntity(
             imageUrl = imageUrl,
             status = status,
             createdAt = createdAt,
+            reason = reason,
         )
 
     fun updateStatus(status: ReportStatus): SpotReportEntity {

--- a/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotCoreRepository.kt
+++ b/sseudam-storage/db-core/src/main/kotlin/com/sseudam/storage/db/core/trashspot/TrashSpotCoreRepository.kt
@@ -147,6 +147,14 @@ class TrashSpotCoreRepository(
         }
     }
 
+    override fun updateAsEmptySpot(spotId: Long) =
+        Tx.writeable {
+            val trashSpot =
+                trashSpotJpaRepository
+                    .findByIdOrElseThrow(spotId)
+            trashSpot.softDelete()
+        }
+
     override fun existsByName(name: String): Boolean =
         Tx.readable {
             trashSpotJpaRepository.existsByName(name)

--- a/sseudam-storage/db-core/src/main/resources/db/migration/V7__add_reason_column_to_spot_report.sql
+++ b/sseudam-storage/db-core/src/main/resources/db/migration/V7__add_reason_column_to_spot_report.sql
@@ -1,0 +1,7 @@
+-- t_spot_report 테이블에 reason 컬럼 추가
+ALTER TABLE t_spot_report ADD COLUMN reason VARCHAR(255);
+
+-- report_type 체크 제약조건 업데이트 (EMPTY_SPOT, ETC 추가)
+ALTER TABLE t_spot_report DROP CONSTRAINT IF EXISTS t_spot_report_report_type_check;
+ALTER TABLE t_spot_report ADD CONSTRAINT t_spot_report_report_type_check 
+CHECK (report_type IN ('POINT', 'KIND', 'PHOTO', 'NAME', 'EMPTY_SPOT', 'ETC'));


### PR DESCRIPTION
## 🌱 관련 이슈
- close #253 

## 📌 작업 내용 및 특이 사항

- 2053f70ab319d5259f46c419cbcf974d7ec5efa8: 기타 사유 타입 및 없는 장소에 대한 신고 케이스 추가

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add optional "reason" to spot reports; visible in report details and notifications.
  - New report types: "Empty Spot" and "Other".
  - "Empty Spot" reports mark a spot as removed and refresh spot details.

- **API Changes**
  - Create Spot Report accepts optional "reason".
  - Admin report update uses "rejectReason" for rejection notes.

- **Documentation**
  - API docs/examples include the optional "reason" field.

- **Tests**
  - Added tests covering reason propagation and EMPTY_SPOT flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->