### PR TITLE
[Refactor] Add userProfile info in admin suggestion&report page

### DIFF
--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/AdminFacade.kt
@@ -1,5 +1,7 @@
 package com.sseudam.admin.application
 
+import com.sseudam.admin.application.report.AdminSpotReportDetail
+import com.sseudam.admin.application.suggestion.AdminSpotSuggestionDetail
 import com.sseudam.admin.domain.AdminToken
 import com.sseudam.admin.domain.AdminUserProfile
 import com.sseudam.auth.AuthenticationService
@@ -82,16 +84,52 @@ class AdminFacade(
     fun findSuggestions(
         offsetPageRequest: OffsetPageRequest,
         searchStatus: SuggestionStatus?,
-    ): Page<SpotSuggestion.Detail> = suggestionService.findSuggestionsBy(offsetPageRequest, searchStatus)
+    ): Page<AdminSpotSuggestionDetail> {
+        val pages = suggestionService.findSuggestionsBy(offsetPageRequest, searchStatus)
+        val users = userService.findAllBy(pages.content.map { it.userId }).associateBy { it.id }
+        val contents =
+            pages.content.map { suggestion ->
+                AdminSpotSuggestionDetail.of(
+                    suggestion,
+                    users[suggestion.userId],
+                )
+            }
+        return Page.of(
+            content = contents,
+            totalCount = pages.totalCount,
+        )
+    }
 
-    fun findSuggestionDetails(suggestionId: Long): SpotSuggestion.Detail = suggestionService.findSpotSuggestionById(suggestionId)
+    fun findSuggestionDetails(suggestionId: Long): AdminSpotSuggestionDetail {
+        val detail = suggestionService.findSpotSuggestionById(suggestionId)
+        val user = userService.getProfile(detail.userId)
+        return AdminSpotSuggestionDetail.of(detail, user)
+    }
 
     fun findReports(
         offsetPageRequest: OffsetPageRequest,
         searchType: ReportType?,
-    ): Page<SpotReport.Detail> = reportService.findReportsBy(offsetPageRequest, searchType)
+    ): Page<AdminSpotReportDetail> {
+        val pages = reportService.findReportsBy(offsetPageRequest, searchType)
+        val users = userService.findAllBy(pages.content.map { it.userId }).associateBy { it.id }
+        val contents =
+            pages.content.map { report ->
+                AdminSpotReportDetail.of(
+                    report,
+                    users[report.userId],
+                )
+            }
+        return Page.of(
+            content = contents,
+            totalCount = pages.totalCount,
+        )
+    }
 
-    fun findReportDetails(reportId: Long): SpotReport.Detail = reportFacade.findReportDetails(reportId)
+    fun findReportDetails(reportId: Long): AdminSpotReportDetail {
+        val detail = reportFacade.findReportDetails(reportId)
+        val user = userService.getProfile(detail.userId)
+        return AdminSpotReportDetail.of(detail, user)
+    }
 
     fun updateSpotSuggestionStatus(command: UpdateSuggestionCommand) =
         SpotSuggestion.UpdateResult.of(

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/report/AdminSpotReportDetail.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/report/AdminSpotReportDetail.kt
@@ -1,0 +1,55 @@
+package com.sseudam.admin.application.report
+
+import com.sseudam.common.Address
+import com.sseudam.common.GeoJson
+import com.sseudam.common.Region
+import com.sseudam.report.ReportStatus
+import com.sseudam.report.ReportType
+import com.sseudam.report.SpotReport
+import com.sseudam.trashspot.TrashType
+import com.sseudam.user.UserProfile
+import java.time.LocalDateTime
+
+data class AdminSpotReportDetail(
+    val id: Long,
+    val spotId: Long,
+    val userId: Long,
+    val userName: String?,
+    val reportType: ReportType,
+    val point: GeoJson,
+    val spotName: String,
+    val region: Region = Region.UNKNOWN,
+    val address: Address,
+    val trashType: TrashType,
+    val imageUrl: String,
+    val status: ReportStatus = ReportStatus.WAITING,
+    val rejectReason: String?,
+    val reason: String?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun of(
+            detail: SpotReport.Detail,
+            user: UserProfile?,
+        ): AdminSpotReportDetail =
+            with(detail) {
+                AdminSpotReportDetail(
+                    id = id,
+                    spotId = spotId,
+                    userId = userId,
+                    userName = user?.name,
+                    reportType = reportType,
+                    point = point,
+                    spotName = spotName,
+                    region = region,
+                    address = address,
+                    trashType = trashType,
+                    imageUrl = imageUrl,
+                    status = status,
+                    rejectReason = rejectReason,
+                    reason = reason,
+                    createdAt = createdAt,
+                )
+            }
+    }
+}

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/suggestion/AdminSpotSuggestionDetail.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/application/suggestion/AdminSpotSuggestionDetail.kt
@@ -1,0 +1,45 @@
+package com.sseudam.admin.application.suggestion
+
+import com.sseudam.common.Address
+import com.sseudam.common.GeoJson
+import com.sseudam.common.Region
+import com.sseudam.suggestion.SpotSuggestion
+import com.sseudam.suggestion.SuggestionStatus
+import com.sseudam.trashspot.TrashType
+import com.sseudam.user.UserProfile
+import java.time.LocalDateTime
+
+data class AdminSpotSuggestionDetail(
+    val id: Long,
+    val userId: Long,
+    val userName: String?,
+    val spotName: String,
+    val point: GeoJson,
+    val region: Region,
+    val address: Address,
+    val trashType: TrashType,
+    val imageUrl: String,
+    val status: SuggestionStatus = SuggestionStatus.WAITING,
+    val rejectReason: String?,
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun of(
+            detail: SpotSuggestion.Detail,
+            user: UserProfile?,
+        ) = AdminSpotSuggestionDetail(
+            id = detail.id,
+            userId = detail.userId,
+            userName = user?.name,
+            spotName = detail.spotName,
+            point = detail.point,
+            region = detail.region,
+            address = detail.address,
+            trashType = detail.trashType,
+            imageUrl = detail.imageUrl,
+            status = detail.status,
+            rejectReason = detail.rejectReason,
+            createdAt = detail.createdAt,
+        )
+    }
+}

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/report/SpotReportAdminResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/report/SpotReportAdminResponse.kt
@@ -1,10 +1,10 @@
 package com.sseudam.admin.presentation.response.report
 
+import com.sseudam.admin.application.report.AdminSpotReportDetail
 import com.sseudam.common.Address
 import com.sseudam.common.GeoJson
 import com.sseudam.report.ReportStatus
 import com.sseudam.report.ReportType
-import com.sseudam.report.SpotReport
 import com.sseudam.trashspot.TrashType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -17,6 +17,8 @@ data class SpotReportAdminResponse(
     val spotId: Long,
     @Schema(description = "신고자 ID")
     val userId: Long,
+    @Schema(description = "신고자 이름")
+    val userName: String?,
     @Schema(description = "신고 타입")
     val reportType: ReportType,
     @Schema(description = "신고 위치")
@@ -37,11 +39,12 @@ data class SpotReportAdminResponse(
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun of(detail: SpotReport.Detail) =
+        fun of(detail: AdminSpotReportDetail) =
             SpotReportAdminResponse(
                 id = detail.id,
                 spotId = detail.spotId,
                 userId = detail.userId,
+                userName = detail.userName,
                 reportType = detail.reportType,
                 point = detail.point,
                 address = detail.address,

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/report/SpotReportAllAdminResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/report/SpotReportAllAdminResponse.kt
@@ -1,6 +1,6 @@
 package com.sseudam.admin.presentation.response.report
 
-import com.sseudam.report.SpotReport
+import com.sseudam.admin.application.report.AdminSpotReportDetail
 import com.sseudam.support.page.Page
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -10,7 +10,7 @@ data class SpotReportAllAdminResponse(
     val totalCount: Long,
 ) {
     companion object {
-        fun of(page: Page<SpotReport.Detail>): SpotReportAllAdminResponse =
+        fun of(page: Page<AdminSpotReportDetail>): SpotReportAllAdminResponse =
             SpotReportAllAdminResponse(
                 list = page.content.map { SpotReportAdminResponse.of(it) },
                 totalCount = page.totalCount,

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAdminResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAdminResponse.kt
@@ -1,9 +1,9 @@
 package com.sseudam.admin.presentation.response.suggestion
 
+import com.sseudam.admin.application.suggestion.AdminSpotSuggestionDetail
 import com.sseudam.common.Address
 import com.sseudam.common.GeoJson
 import com.sseudam.common.Region
-import com.sseudam.suggestion.SpotSuggestion
 import com.sseudam.suggestion.SuggestionStatus
 import com.sseudam.trashspot.TrashType
 import io.swagger.v3.oas.annotations.media.Schema
@@ -13,6 +13,10 @@ import java.time.LocalDateTime
 data class SpotSuggestionAdminResponse(
     @Schema(description = "제보 ID")
     val id: Long,
+    @Schema(description = "제보자 ID")
+    val userId: Long,
+    @Schema(description = "제보자 이름")
+    val userName: String?,
     @Schema(description = "제보 위치")
     val point: GeoJson,
     @Schema(description = "제보 장소 이름")
@@ -33,9 +37,11 @@ data class SpotSuggestionAdminResponse(
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun of(suggestion: SpotSuggestion.Detail) =
+        fun of(suggestion: AdminSpotSuggestionDetail) =
             SpotSuggestionAdminResponse(
                 id = suggestion.id,
+                userId = suggestion.userId,
+                userName = suggestion.userName,
                 point = suggestion.point,
                 spotName = suggestion.spotName,
                 region = suggestion.region,

--- a/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAllAdminResponse.kt
+++ b/sseudam-admin/src/main/kotlin/com/sseudam/admin/presentation/response/suggestion/SpotSuggestionAllAdminResponse.kt
@@ -1,6 +1,6 @@
 package com.sseudam.admin.presentation.response.suggestion
 
-import com.sseudam.suggestion.SpotSuggestion
+import com.sseudam.admin.application.suggestion.AdminSpotSuggestionDetail
 import com.sseudam.support.page.Page
 
 data class SpotSuggestionAllAdminResponse(
@@ -8,7 +8,7 @@ data class SpotSuggestionAllAdminResponse(
     val totalCount: Long,
 ) {
     companion object {
-        fun of(page: Page<SpotSuggestion.Detail>) =
+        fun of(page: Page<AdminSpotSuggestionDetail>) =
             SpotSuggestionAllAdminResponse(
                 list = page.content.map { SpotSuggestionAdminResponse.of(it) },
                 totalCount = page.totalCount,


### PR DESCRIPTION
## 🌱 관련 이슈
- close #279 

## 📌 작업 내용 및 특이 사항

- abb462ceed42f209f1d6372d1cd4b7a14c0080b9: 어드민 제보/신고 페이지 사용자 이름 추가

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can see submitter names and IDs for spot suggestions and reports in list and detail responses.

* **Refactor**
  * Admin endpoints now return enriched suggestion and report data that include submitter information and preserve paging/counts for improved admin context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->